### PR TITLE
[exp-v1.28-lts] backport streaming json feature

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -829,6 +829,10 @@ const (
 	// Enables a StatefulSet to start from an arbitrary non zero ordinal
 	StatefulSetStartOrdinal featuregate.Feature = "StatefulSetStartOrdinal"
 
+	// owner: @serathius
+	// Allow API server to encode collections item by item, instead of all at once.
+	StreamingCollectionEncodingToJSON featuregate.Feature = "StreamingCollectionEncodingToJSON"
+
 	// owner: @robscott
 	// kep: https://kep.k8s.io/2433
 	// alpha: v1.21

--- a/pkg/registry/core/rest/storage_core_generic.go
+++ b/pkg/registry/core/rest/storage_core_generic.go
@@ -20,16 +20,19 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	restclient "k8s.io/client-go/rest"
 
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
 	configmapstore "k8s.io/kubernetes/pkg/registry/core/configmap/storage"
 	eventstore "k8s.io/kubernetes/pkg/registry/core/event/storage"
 	namespacestore "k8s.io/kubernetes/pkg/registry/core/namespace/storage"
@@ -62,6 +65,14 @@ func (c *GenericConfig) NewRESTStorage(apiResourceConfigSource serverstorage.API
 		Scheme:                       legacyscheme.Scheme,
 		ParameterCodec:               legacyscheme.ParameterCodec,
 		NegotiatedSerializer:         legacyscheme.Codecs,
+	}
+
+	opts := []serializer.CodecFactoryOptionsMutator{}
+	if utilfeature.DefaultFeatureGate.Enabled(features.StreamingCollectionEncodingToJSON) {
+		opts = append(opts, serializer.WithStreamingCollectionEncodingToJSON())
+	}
+	if len(opts) != 0 {
+		apiGroupInfo.NegotiatedSerializer = serializer.NewCodecFactory(legacyscheme.Scheme, opts...)
 	}
 
 	eventStorage, err := eventstore.NewREST(restOptionsGetter, uint64(c.EventTTL.Seconds()))

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/crdserverscheme"
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource"
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor"
+	"k8s.io/kubernetes/pkg/features"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -71,6 +72,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericfilters "k8s.io/apiserver/pkg/server/filters"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/util/webhook"
 	"k8s.io/apiserver/pkg/warning"
 	"k8s.io/client-go/scale"
@@ -897,7 +899,11 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 		scaleScope := *requestScopes[v.Name]
 		scaleConverter := scale.NewScaleConverter()
 		scaleScope.Subresource = "scale"
-		scaleScope.Serializer = serializer.NewCodecFactory(scaleConverter.Scheme())
+		var opts []serializer.CodecFactoryOptionsMutator
+		if utilfeature.DefaultFeatureGate.Enabled(features.StreamingCollectionEncodingToJSON) {
+			opts = append(opts, serializer.WithStreamingCollectionEncodingToJSON())
+		}
+		scaleScope.Serializer = serializer.NewCodecFactory(scaleConverter.Scheme(), opts...)
 		scaleScope.Kind = autoscalingv1.SchemeGroupVersion.WithKind("Scale")
 		scaleScope.Namer = handlers.ContextBasedNaming{
 			Namer:         meta.NewAccessor(),

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/help.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/help.go
@@ -221,6 +221,9 @@ func extractList(obj runtime.Object, allocNew bool) ([]runtime.Object, error) {
 	if err != nil {
 		return nil, err
 	}
+	if items.IsNil() {
+		return nil, nil
+	}
 	list := make([]runtime.Object, items.Len())
 	if len(list) == 0 {
 		return list, nil

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
@@ -52,7 +52,7 @@ type serializerType struct {
 func newSerializersForScheme(scheme *runtime.Scheme, mf json.MetaFactory, options CodecFactoryOptions) []serializerType {
 	jsonSerializer := json.NewSerializerWithOptions(
 		mf, scheme, scheme,
-		json.SerializerOptions{Yaml: false, Pretty: false, Strict: options.Strict},
+		json.SerializerOptions{Yaml: false, Pretty: false, Strict: options.Strict, StreamingCollectionsEncoding: options.StreamingCollectionsEncodingToJSON},
 	)
 	jsonSerializerType := serializerType{
 		AcceptContentTypes: []string{runtime.ContentTypeJSON},
@@ -136,6 +136,8 @@ type CodecFactoryOptions struct {
 	Strict bool
 	// Pretty includes a pretty serializer along with the non-pretty one
 	Pretty bool
+
+	StreamingCollectionsEncodingToJSON bool
 }
 
 // CodecFactoryOptionsMutator takes a pointer to an options struct and then modifies it.
@@ -160,6 +162,12 @@ func EnableStrict(options *CodecFactoryOptions) {
 // DisableStrict disables configuring all serializers in strict mode
 func DisableStrict(options *CodecFactoryOptions) {
 	options.Strict = false
+}
+
+func WithStreamingCollectionEncodingToJSON() CodecFactoryOptionsMutator {
+	return func(options *CodecFactoryOptions) {
+		options.StreamingCollectionsEncodingToJSON = true
+	}
 }
 
 // NewCodecFactory provides methods for retrieving serializers for the supported wire formats

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package json
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/conversion"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func streamEncodeCollections(obj runtime.Object, w io.Writer) (bool, error) {
+	list, ok := obj.(*unstructured.UnstructuredList)
+	if ok {
+		return true, streamingEncodeUnstructuredList(w, list)
+	}
+	if _, ok := obj.(json.Marshaler); ok {
+		return false, nil
+	}
+	typeMeta, listMeta, items, err := getListMeta(obj)
+	if err == nil {
+		return true, streamingEncodeList(w, typeMeta, listMeta, items)
+	}
+	return false, nil
+}
+
+// getListMeta implements list extraction logic for json stream serialization.
+//
+// Reason for a custom logic instead of reusing accessors from meta package:
+// * Validate json tags to prevent incompatibility with json standard package.
+// * ListMetaAccessor doesn't distinguish empty from nil value.
+// * TypeAccessort reparsing "apiVersion" and serializing it with "{group}/{version}"
+func getListMeta(list runtime.Object) (metav1.TypeMeta, metav1.ListMeta, []runtime.Object, error) {
+	listValue, err := conversion.EnforcePtr(list)
+	if err != nil {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, err
+	}
+	listType := listValue.Type()
+	if listType.NumField() != 3 {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf("expected ListType to have 3 fields")
+	}
+	// TypeMeta
+	typeMeta, ok := listValue.Field(0).Interface().(metav1.TypeMeta)
+	if !ok {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf("expected TypeMeta field to have TypeMeta type")
+	}
+	if listType.Field(0).Tag.Get("json") != ",inline" {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf(`expected TypeMeta json field tag to be ",inline"`)
+	}
+	// ListMeta
+	listMeta, ok := listValue.Field(1).Interface().(metav1.ListMeta)
+	if !ok {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf("expected ListMeta field to have ListMeta type")
+	}
+	if listType.Field(1).Tag.Get("json") != "metadata,omitempty" {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf(`expected ListMeta json field tag to be "metadata,omitempty"`)
+	}
+	// Items
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, err
+	}
+	if listType.Field(2).Tag.Get("json") != "items" {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf(`expected Items json field tag to be "items"`)
+	}
+	return typeMeta, listMeta, items, nil
+}
+
+func streamingEncodeList(w io.Writer, typeMeta metav1.TypeMeta, listMeta metav1.ListMeta, items []runtime.Object) error {
+	// Start
+	if _, err := w.Write([]byte(`{`)); err != nil {
+		return err
+	}
+
+	// TypeMeta
+	if typeMeta.Kind != "" {
+		if err := encodeKeyValuePair(w, "kind", typeMeta.Kind, []byte(",")); err != nil {
+			return err
+		}
+	}
+	if typeMeta.APIVersion != "" {
+		if err := encodeKeyValuePair(w, "apiVersion", typeMeta.APIVersion, []byte(",")); err != nil {
+			return err
+		}
+	}
+
+	// ListMeta
+	if err := encodeKeyValuePair(w, "metadata", listMeta, []byte(",")); err != nil {
+		return err
+	}
+
+	// Items
+	if err := encodeItemsObjectSlice(w, items); err != nil {
+		return err
+	}
+
+	// End
+	_, err := w.Write([]byte("}\n"))
+	return err
+}
+
+func encodeItemsObjectSlice(w io.Writer, items []runtime.Object) (err error) {
+	if items == nil {
+		err := encodeKeyValuePair(w, "items", nil, nil)
+		return err
+	}
+	_, err = w.Write([]byte(`"items":[`))
+	if err != nil {
+		return err
+	}
+	suffix := []byte(",")
+	for i, item := range items {
+		if i == len(items)-1 {
+			suffix = nil
+		}
+		err := encodeValue(w, item, suffix)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = w.Write([]byte("]"))
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func streamingEncodeUnstructuredList(w io.Writer, list *unstructured.UnstructuredList) error {
+	_, err := w.Write([]byte(`{`))
+	if err != nil {
+		return err
+	}
+	keys := mapsKeys(list.Object)
+	if _, exists := list.Object["items"]; !exists {
+		keys = append(keys, "items")
+	}
+	sort.Strings(keys)
+
+	suffix := []byte(",")
+	for i, key := range keys {
+		if i == len(keys)-1 {
+			suffix = nil
+		}
+		if key == "items" {
+			err = encodeItemsUnstructuredSlice(w, list.Items, suffix)
+		} else {
+			err = encodeKeyValuePair(w, key, list.Object[key], suffix)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	_, err = w.Write([]byte("}\n"))
+	return err
+}
+
+func encodeItemsUnstructuredSlice(w io.Writer, items []unstructured.Unstructured, suffix []byte) (err error) {
+	_, err = w.Write([]byte(`"items":[`))
+	if err != nil {
+		return err
+	}
+	comma := []byte(",")
+	for i, item := range items {
+		if i == len(items)-1 {
+			comma = nil
+		}
+		err := encodeValue(w, item.Object, comma)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = w.Write([]byte("]"))
+	if err != nil {
+		return err
+	}
+	if len(suffix) > 0 {
+		_, err = w.Write(suffix)
+	}
+	return err
+}
+
+func encodeKeyValuePair(w io.Writer, key string, value any, suffix []byte) (err error) {
+	err = encodeValue(w, key, []byte(":"))
+	if err != nil {
+		return err
+	}
+	err = encodeValue(w, value, suffix)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func encodeValue(w io.Writer, value any, suffix []byte) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	if err != nil {
+		return err
+	}
+	if len(suffix) > 0 {
+		_, err = w.Write(suffix)
+	}
+	return err
+}
+
+func mapsKeys[M ~map[K]V, K comparable, V any](m M) []K {
+	r := make([]K, 0, len(m))
+	for k := range m {
+		r = append(r, k)
+	}
+	return r
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections_test.go
@@ -1,0 +1,655 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package json
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	testapigroupv1 "k8s.io/apimachinery/pkg/apis/testapigroup/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestCollectionsEncoding(t *testing.T) {
+	t.Run("Normal", func(t *testing.T) {
+		testCollectionsEncoding(t, NewSerializerWithOptions(DefaultMetaFactory, nil, nil, SerializerOptions{}))
+	})
+	// Leave place for testing streaming collection serializer proposed as part of KEP-5116
+}
+
+// testCollectionsEncoding should provide comprehensive tests to validate streaming implementation of encoder.
+func testCollectionsEncoding(t *testing.T, s *Serializer) {
+	var buf bytes.Buffer
+	var remainingItems int64 = 1
+	// As defined in KEP-5116 we it should include the following scenarios:
+	// Context: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5116-streaming-response-encoding#unit-tests
+	for _, tc := range []struct {
+		name   string
+		in     runtime.Object
+		expect string
+	}{
+		// Preserving the distinction between integers and floating-point numbers
+		{
+			name: "Struct with floats",
+			in: &StructWithFloatsList{
+				Items: []StructWithFloats{
+					{
+						Int:     1,
+						Float32: float32(1),
+						Float64: 1.1,
+					},
+				},
+			},
+			expect: "{\"metadata\":{},\"items\":[{\"metadata\":{\"creationTimestamp\":null},\"Int\":1,\"Float32\":1,\"Float64\":1.1}]}\n",
+		},
+		{
+			name: "Unstructured object float",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"int":     1,
+					"float32": float32(1),
+					"float64": 1.1,
+				},
+			},
+			expect: "{\"float32\":1,\"float64\":1.1,\"int\":1,\"items\":[]}\n",
+		},
+		{
+			name: "Unstructured items float",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"int":     1,
+							"float32": float32(1),
+							"float64": 1.1,
+						},
+					},
+				},
+			},
+			expect: "{\"items\":[{\"float32\":1,\"float64\":1.1,\"int\":1}]}\n",
+		},
+		// Handling structs with duplicate field names (JSON tag names) without producing duplicate keys in the encoded output
+		{
+			name: "StructWithDuplicatedTags",
+			in: &StructWithDuplicatedTagsList{
+				Items: []StructWithDuplicatedTags{
+					{
+						Key1: "key1",
+						Key2: "key2",
+					},
+				},
+			},
+			expect: "{\"metadata\":{},\"items\":[{\"metadata\":{\"creationTimestamp\":null}}]}\n",
+		},
+		// Encoding Go strings containing invalid UTF-8 sequences without error
+		{
+			name: "UnstructuredList object invalid UTF-8 ",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"key": "\x80", // first byte is a continuation byte
+				},
+			},
+			expect: "{\"items\":[],\"key\":\"\\ufffd\"}\n",
+		},
+		{
+			name: "UnstructuredList items invalid UTF-8 ",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"key": "\x80", // first byte is a continuation byte
+						},
+					},
+				},
+			},
+			expect: "{\"items\":[{\"key\":\"\\ufffd\"}]}\n",
+		},
+		// Preserving the distinction between absent, present-but-null, and present-and-empty states for slices and maps
+		{
+			name: "CarpList items nil",
+			in: &testapigroupv1.CarpList{
+				Items: nil,
+			},
+			expect: "{\"metadata\":{},\"items\":null}\n",
+		},
+		{
+			name: "CarpList slice nil",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{
+					{
+						Status: testapigroupv1.CarpStatus{
+							Conditions: nil,
+						},
+					},
+				},
+			},
+			expect: "{\"metadata\":{},\"items\":[{\"metadata\":{\"creationTimestamp\":null},\"spec\":{},\"status\":{}}]}\n",
+		},
+		{
+			name: "CarpList map nil",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{
+					{
+						Spec: testapigroupv1.CarpSpec{
+							NodeSelector: nil,
+						},
+					},
+				},
+			},
+			expect: "{\"metadata\":{},\"items\":[{\"metadata\":{\"creationTimestamp\":null},\"spec\":{},\"status\":{}}]}\n",
+		},
+		{
+			name: "UnstructuredList items nil",
+			in: &unstructured.UnstructuredList{
+				Items: nil,
+			},
+			expect: "{\"items\":[]}\n",
+		},
+		{
+			name: "UnstructuredList items slice nil",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"slice": ([]string)(nil),
+						},
+					},
+				},
+			},
+			expect: "{\"items\":[{\"slice\":null}]}\n",
+		},
+		{
+			name: "UnstructuredList items map nil",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"map": (map[string]string)(nil),
+						},
+					},
+				},
+			},
+			expect: "{\"items\":[{\"map\":null}]}\n",
+		},
+		{
+			name: "UnstructuredList object nil",
+			in: &unstructured.UnstructuredList{
+				Object: nil,
+			},
+			expect: "{\"items\":[]}\n",
+		},
+		{
+			name: "UnstructuredList object slice nil",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"slice": ([]string)(nil),
+				},
+			},
+			expect: "{\"items\":[],\"slice\":null}\n",
+		},
+		{
+			name: "UnstructuredList object map nil",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"map": (map[string]string)(nil),
+				},
+			},
+			expect: "{\"items\":[],\"map\":null}\n",
+		},
+		{
+			name: "CarpList items empty",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{},
+			},
+			expect: "{\"metadata\":{},\"items\":[]}\n",
+		},
+		{
+			name: "CarpList slice empty",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{
+					{
+						Status: testapigroupv1.CarpStatus{
+							Conditions: []testapigroupv1.CarpCondition{},
+						},
+					},
+				},
+			},
+			expect: "{\"metadata\":{},\"items\":[{\"metadata\":{\"creationTimestamp\":null},\"spec\":{},\"status\":{}}]}\n",
+		},
+		{
+			name: "CarpList map empty",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{
+					{
+						Spec: testapigroupv1.CarpSpec{
+							NodeSelector: map[string]string{},
+						},
+					},
+				},
+			},
+			expect: "{\"metadata\":{},\"items\":[{\"metadata\":{\"creationTimestamp\":null},\"spec\":{},\"status\":{}}]}\n",
+		},
+		{
+			name: "UnstructuredList items empty",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{},
+			},
+			expect: "{\"items\":[]}\n",
+		},
+		{
+			name: "UnstructuredList items slice empty",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"slice": []string{},
+						},
+					},
+				},
+			},
+			expect: "{\"items\":[{\"slice\":[]}]}\n",
+		},
+		{
+			name: "UnstructuredList items map empty",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"map": map[string]string{},
+						},
+					},
+				},
+			},
+			expect: "{\"items\":[{\"map\":{}}]}\n",
+		},
+		{
+			name: "UnstructuredList object empty",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{},
+			},
+			expect: "{\"items\":[]}\n",
+		},
+		{
+			name: "UnstructuredList object slice empty",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"slice": []string{},
+				},
+			},
+			expect: "{\"items\":[],\"slice\":[]}\n",
+		},
+		{
+			name: "UnstructuredList object map empty",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"map": map[string]string{},
+				},
+			},
+			expect: "{\"items\":[],\"map\":{}}\n",
+		},
+		// Handling structs implementing MarshallJSON method, especially built-in collection types.
+		{
+			name:   "List with MarshallJSON",
+			in:     &ListWithMarshalJSONList{},
+			expect: "\"marshallJSON\"\n",
+		},
+		{
+			name: "Struct with MarshallJSON",
+			in: &StructWithMarshalJSONList{
+				Items: []StructWithMarshalJSON{
+					{},
+				},
+			},
+			expect: "{\"metadata\":{},\"items\":[\"marshallJSON\"]}\n",
+		},
+		// Handling raw bytes.
+		{
+			name: "Struct with raw bytes",
+			in: &StructWithRawBytesList{
+				Items: []StructWithRawBytes{
+					{
+						Slice: []byte{0x01, 0x02, 0x03},
+						Array: [3]byte{0x01, 0x02, 0x03},
+					},
+				},
+			},
+			expect: "{\"metadata\":{},\"items\":[{\"metadata\":{\"creationTimestamp\":null},\"Slice\":\"AQID\",\"Array\":[1,2,3]}]}\n",
+		},
+		{
+			name: "UnstructuredList object raw bytes",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"slice": []byte{0x01, 0x02, 0x03},
+					"array": [3]byte{0x01, 0x02, 0x03},
+				},
+			},
+			expect: "{\"array\":[1,2,3],\"items\":[],\"slice\":\"AQID\"}\n",
+		},
+		{
+			name: "UnstructuredList items raw bytes",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"slice": []byte{0x01, 0x02, 0x03},
+							"array": [3]byte{0x01, 0x02, 0x03},
+						},
+					},
+				},
+			},
+			expect: "{\"items\":[{\"array\":[1,2,3],\"slice\":\"AQID\"}]}\n",
+		},
+		// Other scenarios:
+		{
+			name: "List just kind",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "List",
+				},
+			},
+			expect: "{\"kind\":\"List\",\"metadata\":{},\"items\":null}\n",
+		},
+		{
+			name: "List just apiVersion",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+			},
+			expect: "{\"apiVersion\":\"v1\",\"metadata\":{},\"items\":null}\n",
+		},
+		{
+			name: "List no elements",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+				ListMeta: metav1.ListMeta{
+					ResourceVersion: "2345",
+				},
+				Items: []testapigroupv1.Carp{},
+			},
+			expect: "{\"kind\":\"List\",\"apiVersion\":\"v1\",\"metadata\":{\"resourceVersion\":\"2345\"},\"items\":[]}\n",
+		},
+		{
+			name: "List one element with continue",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+				ListMeta: metav1.ListMeta{
+					ResourceVersion:    "2345",
+					Continue:           "abc",
+					RemainingItemCount: &remainingItems,
+				},
+				Items: []testapigroupv1.Carp{
+					{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod",
+						Namespace: "default",
+					}},
+				},
+			},
+			expect: "{\"kind\":\"List\",\"apiVersion\":\"v1\",\"metadata\":{\"resourceVersion\":\"2345\",\"continue\":\"abc\",\"remainingItemCount\":1},\"items\":[{\"kind\":\"Carp\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"pod\",\"namespace\":\"default\",\"creationTimestamp\":null},\"spec\":{},\"status\":{}}]}\n",
+		},
+		{
+			name: "List two elements",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+				ListMeta: metav1.ListMeta{
+					ResourceVersion: "2345",
+				},
+				Items: []testapigroupv1.Carp{
+					{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod",
+						Namespace: "default",
+					}},
+					{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod2",
+						Namespace: "default2",
+					}},
+				},
+			},
+			expect: `{"kind":"List","apiVersion":"v1","metadata":{"resourceVersion":"2345"},"items":[{"kind":"Carp","apiVersion":"v1","metadata":{"name":"pod","namespace":"default","creationTimestamp":null},"spec":{},"status":{}},{"kind":"Carp","apiVersion":"v1","metadata":{"name":"pod2","namespace":"default2","creationTimestamp":null},"spec":{},"status":{}}]}
+`,
+		},
+		{
+			name:   "UnstructuredList empty",
+			in:     &unstructured.UnstructuredList{},
+			expect: "{\"items\":[]}\n",
+		},
+		{
+			name: "UnstructuredList just kind",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"kind": "List"},
+			},
+			expect: "{\"items\":[],\"kind\":\"List\"}\n",
+		},
+		{
+			name: "UnstructuredList just apiVersion",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"apiVersion": "v1"},
+			},
+			expect: "{\"apiVersion\":\"v1\",\"items\":[]}\n",
+		},
+		{
+			name: "UnstructuredList no elements",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{"resourceVersion": "2345"}},
+				Items:  []unstructured.Unstructured{},
+			},
+			expect: "{\"apiVersion\":\"v1\",\"items\":[],\"kind\":\"List\",\"metadata\":{\"resourceVersion\":\"2345\"}}\n",
+		},
+		{
+			name: "UnstructuredList one element with continue",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{
+					"resourceVersion":    "2345",
+					"continue":           "abc",
+					"remainingItemCount": "1",
+				}},
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "Carp",
+							"metadata": map[string]interface{}{
+								"name":      "pod",
+								"namespace": "default",
+							},
+						},
+					},
+				},
+			},
+			expect: "{\"apiVersion\":\"v1\",\"items\":[{\"apiVersion\":\"v1\",\"kind\":\"Carp\",\"metadata\":{\"name\":\"pod\",\"namespace\":\"default\"}}],\"kind\":\"List\",\"metadata\":{\"continue\":\"abc\",\"remainingItemCount\":\"1\",\"resourceVersion\":\"2345\"}}\n",
+		},
+		{
+			name: "UnstructuredList two elements",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{
+					"resourceVersion": "2345",
+				}},
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "Carp",
+							"metadata": map[string]interface{}{
+								"name":      "pod",
+								"namespace": "default",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "Carp",
+							"metadata": map[string]interface{}{
+								"name":      "pod2",
+								"namespace": "default",
+							},
+						},
+					},
+				},
+			},
+			expect: "{\"apiVersion\":\"v1\",\"items\":[{\"apiVersion\":\"v1\",\"kind\":\"Carp\",\"metadata\":{\"name\":\"pod\",\"namespace\":\"default\"}},{\"apiVersion\":\"v1\",\"kind\":\"Carp\",\"metadata\":{\"name\":\"pod2\",\"namespace\":\"default\"}}],\"kind\":\"List\",\"metadata\":{\"resourceVersion\":\"2345\"}}\n",
+		},
+		{
+			name: "UnstructuredList conflict on items",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"items": []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"name": "pod",
+						},
+					},
+				},
+				},
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"name": "pod2",
+						},
+					},
+				},
+			},
+			expect: "{\"items\":[{\"name\":\"pod2\"}]}\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			buf.Reset()
+			if err := s.Encode(tc.in, &buf); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			t.Logf("normal: %s", buf.String())
+			if diff := cmp.Diff(buf.String(), tc.expect); diff != "" {
+				t.Errorf("not matching:\n%s", diff)
+			}
+		})
+	}
+}
+
+type StructWithFloatsList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []StructWithFloats `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (l *StructWithFloatsList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type StructWithFloats struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	Int     int
+	Float32 float32
+	Float64 float64
+}
+
+func (s *StructWithFloats) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type StructWithDuplicatedTagsList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []StructWithDuplicatedTags `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (l *StructWithDuplicatedTagsList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type StructWithDuplicatedTags struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	Key1 string `json:"key"`
+	Key2 string `json:"key"` //nolint:govet
+}
+
+func (s *StructWithDuplicatedTags) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type ListWithMarshalJSONList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []string `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (l *ListWithMarshalJSONList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+func (l *ListWithMarshalJSONList) MarshalJSON() ([]byte, error) {
+	return []byte(`"marshallJSON"`), nil
+}
+
+type StructWithMarshalJSONList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []StructWithMarshalJSON `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (s *StructWithMarshalJSONList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type StructWithMarshalJSON struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+}
+
+func (l *StructWithMarshalJSON) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+func (l *StructWithMarshalJSON) MarshalJSON() ([]byte, error) {
+	return []byte(`"marshallJSON"`), nil
+}
+
+type StructWithRawBytesList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []StructWithRawBytes `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (s *StructWithRawBytesList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type StructWithRawBytes struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Slice             []byte
+	Array             [3]byte
+}
+
+func (s *StructWithRawBytes) DeepCopyObject() runtime.Object {
+	return nil
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections_test.go
@@ -18,9 +18,11 @@ package json
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	fuzz "github.com/google/gofuzz"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -30,21 +32,24 @@ import (
 
 func TestCollectionsEncoding(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
-		testCollectionsEncoding(t, NewSerializerWithOptions(DefaultMetaFactory, nil, nil, SerializerOptions{}))
+		testCollectionsEncoding(t, NewSerializerWithOptions(DefaultMetaFactory, nil, nil, SerializerOptions{}), false)
 	})
-	// Leave place for testing streaming collection serializer proposed as part of KEP-5116
+	t.Run("Streaming", func(t *testing.T) {
+		testCollectionsEncoding(t, NewSerializerWithOptions(DefaultMetaFactory, nil, nil, SerializerOptions{StreamingCollectionsEncoding: true}), true)
+	})
 }
 
 // testCollectionsEncoding should provide comprehensive tests to validate streaming implementation of encoder.
-func testCollectionsEncoding(t *testing.T, s *Serializer) {
-	var buf bytes.Buffer
+func testCollectionsEncoding(t *testing.T, s *Serializer, streamingEnabled bool) {
+	var buf writeCountingBuffer
 	var remainingItems int64 = 1
 	// As defined in KEP-5116 we it should include the following scenarios:
 	// Context: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5116-streaming-response-encoding#unit-tests
 	for _, tc := range []struct {
-		name   string
-		in     runtime.Object
-		expect string
+		name         string
+		in           runtime.Object
+		cannotStream bool
+		expect       string
 	}{
 		// Preserving the distinction between integers and floating-point numbers
 		{
@@ -307,9 +312,10 @@ func testCollectionsEncoding(t *testing.T, s *Serializer) {
 		},
 		// Handling structs implementing MarshallJSON method, especially built-in collection types.
 		{
-			name:   "List with MarshallJSON",
-			in:     &ListWithMarshalJSONList{},
-			expect: "\"marshallJSON\"\n",
+			name:         "List with MarshallJSON cannot be streamed",
+			in:           &ListWithMarshalJSONList{},
+			expect:       "\"marshallJSON\"\n",
+			cannotStream: true,
 		},
 		{
 			name: "Struct with MarshallJSON",
@@ -436,6 +442,32 @@ func testCollectionsEncoding(t *testing.T, s *Serializer) {
 `,
 		},
 		{
+			name: "List with extra field cannot be streamed",
+			in: &ListWithAdditionalFields{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+				ListMeta: metav1.ListMeta{
+					ResourceVersion: "2345",
+				},
+				Items: []testapigroupv1.Carp{},
+			},
+			cannotStream: true,
+			expect:       "{\"kind\":\"List\",\"apiVersion\":\"v1\",\"metadata\":{\"resourceVersion\":\"2345\"},\"items\":[],\"AdditionalField\":0}\n",
+		},
+		{
+			name: "Not a collection cannot be streamed",
+			in: &testapigroupv1.Carp{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+			},
+			cannotStream: true,
+			expect:       "{\"kind\":\"List\",\"apiVersion\":\"v1\",\"metadata\":{\"creationTimestamp\":null},\"spec\":{},\"status\":{}}\n",
+		},
+		{
 			name:   "UnstructuredList empty",
 			in:     &unstructured.UnstructuredList{},
 			expect: "{\"items\":[]}\n",
@@ -543,9 +575,16 @@ func testCollectionsEncoding(t *testing.T, s *Serializer) {
 			if err := s.Encode(tc.in, &buf); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			t.Logf("normal: %s", buf.String())
+			t.Logf("encoded: %s", buf.String())
 			if diff := cmp.Diff(buf.String(), tc.expect); diff != "" {
 				t.Errorf("not matching:\n%s", diff)
+			}
+			expectStreaming := !tc.cannotStream && streamingEnabled
+			if expectStreaming && buf.writeCount <= 1 {
+				t.Errorf("expected streaming but Write was called only: %d", buf.writeCount)
+			}
+			if !expectStreaming && buf.writeCount > 1 {
+				t.Errorf("expected non-streaming but Write was called more than once: %d", buf.writeCount)
 			}
 		})
 	}
@@ -652,4 +691,104 @@ type StructWithRawBytes struct {
 
 func (s *StructWithRawBytes) DeepCopyObject() runtime.Object {
 	return nil
+}
+
+type ListWithAdditionalFields struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []testapigroupv1.Carp `json:"items" protobuf:"bytes,2,rep,name=items"`
+	AdditionalField int
+}
+
+func (s *ListWithAdditionalFields) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type writeCountingBuffer struct {
+	writeCount int
+	bytes.Buffer
+}
+
+func (b *writeCountingBuffer) Write(data []byte) (int, error) {
+	b.writeCount++
+	return b.Buffer.Write(data)
+}
+
+func (b *writeCountingBuffer) Reset() {
+	b.writeCount = 0
+	b.Buffer.Reset()
+}
+
+func TestFuzzCollectionsEncoding(t *testing.T) {
+	disableFuzzFieldsV1 := func(field *metav1.FieldsV1, c fuzz.Continue) {}
+	fuzzUnstructuredList := func(list *unstructured.UnstructuredList, c fuzz.Continue) {
+		list.Object = map[string]interface{}{
+			"kind":         "List",
+			"apiVersion":   "v1",
+			c.RandString(): c.RandString(),
+			c.RandString(): c.RandUint64(),
+			c.RandString(): c.RandBool(),
+			"metadata": map[string]interface{}{
+				"resourceVersion":    fmt.Sprintf("%d", c.RandUint64()),
+				"continue":           c.RandString(),
+				"remainingItemCount": fmt.Sprintf("%d", c.RandUint64()),
+				c.RandString():       c.RandString(),
+			}}
+		c.Fuzz(&list.Items)
+	}
+	fuzzMap := func(kvs map[string]interface{}, c fuzz.Continue) {
+		kvs[c.RandString()] = c.RandBool()
+		kvs[c.RandString()] = c.RandUint64()
+		kvs[c.RandString()] = c.RandString()
+	}
+	f := fuzz.New().Funcs(disableFuzzFieldsV1, fuzzUnstructuredList, fuzzMap)
+	streamingBuffer := &bytes.Buffer{}
+	normalSerializer := NewSerializerWithOptions(DefaultMetaFactory, nil, nil, SerializerOptions{StreamingCollectionsEncoding: false})
+	normalBuffer := &bytes.Buffer{}
+	t.Run("CarpList", func(t *testing.T) {
+		for i := 0; i < 1000; i++ {
+			list := &testapigroupv1.CarpList{}
+			f.Fuzz(list)
+			streamingBuffer.Reset()
+			normalBuffer.Reset()
+			ok, err := streamEncodeCollections(list, streamingBuffer)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !ok {
+				t.Fatalf("expected streaming encoder to encode %T", list)
+			}
+			if err := normalSerializer.Encode(list, normalBuffer); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(normalBuffer.String(), streamingBuffer.String()); diff != "" {
+				t.Logf("normal: %s", normalBuffer.String())
+				t.Logf("streaming: %s", streamingBuffer.String())
+				t.Errorf("not matching:\n%s", diff)
+			}
+		}
+	})
+	t.Run("UnstructuredList", func(t *testing.T) {
+		for i := 0; i < 1000; i++ {
+			list := &unstructured.UnstructuredList{}
+			f.Fuzz(list)
+			streamingBuffer.Reset()
+			normalBuffer.Reset()
+			ok, err := streamEncodeCollections(list, streamingBuffer)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !ok {
+				t.Fatalf("expected streaming encoder to encode %T", list)
+			}
+			if err := normalSerializer.Encode(list, normalBuffer); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(normalBuffer.String(), streamingBuffer.String()); diff != "" {
+				t.Logf("normal: %s", normalBuffer.String())
+				t.Logf("streaming: %s", streamingBuffer.String())
+				t.Errorf("not matching:\n%s", diff)
+			}
+		}
+	})
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -156,6 +156,9 @@ const (
 	// (usually the entire object), and if the size is smaller no gzipping will be performed
 	// if the client requests it.
 	defaultGzipThresholdBytes = 128 * 1024
+	// Use the length of the first write of streaming implementations.
+	// TODO: Update when streaming proto is implemented
+	firstWriteStreamingThresholdBytes = 1
 )
 
 // negotiateContentEncoding returns a supported client-requested content encoding for the
@@ -191,14 +194,53 @@ type deferredResponseWriter struct {
 	statusCode      int
 	contentEncoding string
 
-	hasWritten bool
-	hw         http.ResponseWriter
-	w          io.Writer
+	hasBuffered bool
+	buffer      []byte
+	hasWritten  bool
+	hw          http.ResponseWriter
+	w           io.Writer
 
 	ctx context.Context
 }
 
 func (w *deferredResponseWriter) Write(p []byte) (n int, err error) {
+	switch {
+	case w.hasWritten:
+		// already written, cannot buffer
+		return w.unbufferedWrite(p)
+
+	case w.contentEncoding != "gzip":
+		// non-gzip, no need to buffer
+		return w.unbufferedWrite(p)
+
+	case !w.hasBuffered && len(p) > defaultGzipThresholdBytes:
+		// not yet buffered, first write is long enough to trigger gzip, no need to buffer
+		return w.unbufferedWrite(p)
+
+	case !w.hasBuffered && len(p) > firstWriteStreamingThresholdBytes:
+		// not yet buffered, first write is longer than expected for streaming scenarios that would require buffering, no need to buffer
+		return w.unbufferedWrite(p)
+
+	default:
+		if !w.hasBuffered {
+			w.hasBuffered = true
+			// Start at 80 bytes to avoid rapid reallocation of the buffer.
+			// The minimum size of a 0-item serialized list object is 80 bytes:
+			// {"kind":"List","apiVersion":"v1","metadata":{"resourceVersion":"1"},"items":[]}\n
+			w.buffer = make([]byte, 0, max(80, len(p)))
+		}
+		w.buffer = append(w.buffer, p...)
+		var err error
+		if len(w.buffer) > defaultGzipThresholdBytes {
+			// we've accumulated enough to trigger gzip, write and clear buffer
+			_, err = w.unbufferedWrite(w.buffer)
+			w.buffer = nil
+		}
+		return len(p), err
+	}
+}
+
+func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
 	ctx := w.ctx
 	span := tracing.SpanFromContext(ctx)
 	// This Step usually wraps in-memory object serialization.
@@ -244,11 +286,17 @@ func (w *deferredResponseWriter) Write(p []byte) (n int, err error) {
 	return w.w.Write(p)
 }
 
-func (w *deferredResponseWriter) Close() error {
+func (w *deferredResponseWriter) Close() (err error) {
 	if !w.hasWritten {
-		return nil
+		if !w.hasBuffered {
+			return nil
+		}
+		// never reached defaultGzipThresholdBytes, no need to do the gzip writer cleanup
+		_, err := w.unbufferedWrite(w.buffer)
+		w.buffer = nil
+		return err
 	}
-	var err error
+
 	switch t := w.w.(type) {
 	case *gzip.Writer:
 		err = t.Close()
@@ -340,4 +388,11 @@ func WriteRawJSON(statusCode int, object interface{}, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	w.Write(output)
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -199,6 +199,10 @@ type deferredResponseWriter struct {
 	hasWritten  bool
 	hw          http.ResponseWriter
 	w           io.Writer
+	// totalBytes is the number of bytes written to `w` and does not include buffered bytes
+	totalBytes int
+	// lastWriteErr holds the error result (if any) of the last write attempt to `w`
+	lastWriteErr error
 
 	ctx context.Context
 }
@@ -241,26 +245,11 @@ func (w *deferredResponseWriter) Write(p []byte) (n int, err error) {
 }
 
 func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
-	ctx := w.ctx
-	span := tracing.SpanFromContext(ctx)
-	// This Step usually wraps in-memory object serialization.
-	span.AddEvent("About to start writing response", attribute.Int("size", len(p)))
-
-	firstWrite := !w.hasWritten
 	defer func() {
-		if err != nil {
-			span.AddEvent("Write call failed",
-				attribute.String("writer", fmt.Sprintf("%T", w.w)),
-				attribute.Int("size", len(p)),
-				attribute.Bool("firstWrite", firstWrite),
-				attribute.String("err", err.Error()))
-		} else {
-			span.AddEvent("Write call succeeded",
-				attribute.String("writer", fmt.Sprintf("%T", w.w)),
-				attribute.Int("size", len(p)),
-				attribute.Bool("firstWrite", firstWrite))
-		}
+		w.totalBytes += n
+		w.lastWriteErr = err
 	}()
+
 	if w.hasWritten {
 		return w.w.Write(p)
 	}
@@ -281,12 +270,35 @@ func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
 		w.w = hw
 	}
 
+	span := tracing.SpanFromContext(w.ctx)
+	span.AddEvent("About to start writing response",
+		attribute.String("writer", fmt.Sprintf("%T", w.w)),
+		attribute.Int("size", len(p)),
+	)
+
 	header.Set("Content-Type", w.mediaType)
 	hw.WriteHeader(w.statusCode)
 	return w.w.Write(p)
 }
 
 func (w *deferredResponseWriter) Close() (err error) {
+	defer func() {
+		if !w.hasWritten {
+			return
+		}
+
+		span := tracing.SpanFromContext(w.ctx)
+
+		if w.lastWriteErr != nil {
+			span.AddEvent("Write call failed",
+				attribute.Int("size", w.totalBytes),
+				attribute.String("err", w.lastWriteErr.Error()))
+		} else {
+			span.AddEvent("Write call succeeded",
+				attribute.Int("size", w.totalBytes))
+		}
+	}()
+
 	if !w.hasWritten {
 		if !w.hasBuffered {
 			return nil

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
@@ -33,7 +33,6 @@ import (
 	"os"
 	"reflect"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -42,6 +41,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	rand2 "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -381,29 +381,94 @@ func TestDeferredResponseWriter_Write(t *testing.T) {
 	largeChunk := bytes.Repeat([]byte("b"), defaultGzipThresholdBytes+1)
 
 	tests := []struct {
-		name       string
-		chunks     [][]byte
-		expectGzip bool
+		name          string
+		chunks        [][]byte
+		expectGzip    bool
+		expectHeaders http.Header
 	}{
+		{
+			name:          "no writes",
+			chunks:        nil,
+			expectGzip:    false,
+			expectHeaders: http.Header{},
+		},
+		{
+			name:       "one empty write",
+			chunks:     [][]byte{{}},
+			expectGzip: false,
+			expectHeaders: http.Header{
+				"Content-Type": []string{"text/plain"},
+			},
+		},
+		{
+			name:       "one single byte write",
+			chunks:     [][]byte{{'{'}},
+			expectGzip: false,
+			expectHeaders: http.Header{
+				"Content-Type": []string{"text/plain"},
+			},
+		},
 		{
 			name:       "one small chunk write",
 			chunks:     [][]byte{smallChunk},
 			expectGzip: false,
+			expectHeaders: http.Header{
+				"Content-Type": []string{"text/plain"},
+			},
 		},
 		{
 			name:       "two small chunk writes",
 			chunks:     [][]byte{smallChunk, smallChunk},
 			expectGzip: false,
+			expectHeaders: http.Header{
+				"Content-Type": []string{"text/plain"},
+			},
+		},
+		{
+			name:       "one single byte and one small chunk write",
+			chunks:     [][]byte{{'{'}, smallChunk},
+			expectGzip: false,
+			expectHeaders: http.Header{
+				"Content-Type": []string{"text/plain"},
+			},
+		},
+		{
+			name:       "two single bytes and one small chunk write",
+			chunks:     [][]byte{{'{'}, {'{'}, smallChunk},
+			expectGzip: true,
+			expectHeaders: http.Header{
+				"Content-Type":     []string{"text/plain"},
+				"Content-Encoding": []string{"gzip"},
+				"Vary":             []string{"Accept-Encoding"},
+			},
 		},
 		{
 			name:       "one large chunk writes",
 			chunks:     [][]byte{largeChunk},
 			expectGzip: true,
+			expectHeaders: http.Header{
+				"Content-Type":     []string{"text/plain"},
+				"Content-Encoding": []string{"gzip"},
+				"Vary":             []string{"Accept-Encoding"},
+			},
 		},
 		{
 			name:       "two large chunk writes",
 			chunks:     [][]byte{largeChunk, largeChunk},
 			expectGzip: true,
+			expectHeaders: http.Header{
+				"Content-Type":     []string{"text/plain"},
+				"Content-Encoding": []string{"gzip"},
+				"Vary":             []string{"Accept-Encoding"},
+			},
+		},
+		{
+			name:       "one small chunk and one large chunk write",
+			chunks:     [][]byte{smallChunk, largeChunk},
+			expectGzip: false,
+			expectHeaders: http.Header{
+				"Content-Type": []string{"text/plain"},
+			},
 		},
 	}
 
@@ -444,8 +509,9 @@ func TestDeferredResponseWriter_Write(t *testing.T) {
 			if res.StatusCode != http.StatusOK {
 				t.Fatalf("status code is not writtend properly, expected: 200, got: %d", res.StatusCode)
 			}
-			contentEncoding := res.Header.Get("Content-Encoding")
-			varyHeader := res.Header.Get("Vary")
+			if !reflect.DeepEqual(res.Header, tt.expectHeaders) {
+				t.Fatal(cmp.Diff(tt.expectHeaders, res.Header))
+			}
 
 			resBytes, err := io.ReadAll(res.Body)
 			if err != nil {
@@ -453,14 +519,6 @@ func TestDeferredResponseWriter_Write(t *testing.T) {
 			}
 
 			if tt.expectGzip {
-				if contentEncoding != "gzip" {
-					t.Fatalf("content-encoding is not set properly, expected: gzip, got: %s", contentEncoding)
-				}
-
-				if !strings.Contains(varyHeader, "Accept-Encoding") {
-					t.Errorf("vary header doesn't have Accept-Encoding")
-				}
-
 				gr, err := gzip.NewReader(bytes.NewReader(resBytes))
 				if err != nil {
 					t.Fatalf("failed to create gzip reader: %v", err)
@@ -474,22 +532,101 @@ func TestDeferredResponseWriter_Write(t *testing.T) {
 				if !bytes.Equal(fullPayload, decompressed) {
 					t.Errorf("payload mismatch, expected: %s, got: %s", fullPayload, decompressed)
 				}
-
 			} else {
-				if contentEncoding != "" {
-					t.Errorf("content-encoding is set unexpectedly")
-				}
-
-				if strings.Contains(varyHeader, "Accept-Encoding") {
-					t.Errorf("accept encoding is set unexpectedly")
-				}
-
 				if !bytes.Equal(fullPayload, resBytes) {
 					t.Errorf("payload mismatch, expected: %s, got: %s", fullPayload, resBytes)
 				}
-
 			}
+		})
+	}
+}
 
+func benchmarkChunkingGzip(b *testing.B, count int, chunk []byte) {
+	mockResponseWriter := httptest.NewRecorder()
+	mockResponseWriter.Body = nil
+
+	drw := &deferredResponseWriter{
+		mediaType:       "text/plain",
+		statusCode:      200,
+		contentEncoding: "gzip",
+		hw:              mockResponseWriter,
+		ctx:             context.Background(),
+	}
+	b.ResetTimer()
+	for i := 0; i < count; i++ {
+		n, err := drw.Write(chunk)
+		if err != nil {
+			b.Fatalf("unexpected error while writing chunk: %v", err)
+		}
+		if n != len(chunk) {
+			b.Errorf("write is not complete, expected: %d bytes, written: %d bytes", len(chunk), n)
+		}
+	}
+	err := drw.Close()
+	if err != nil {
+		b.Fatalf("unexpected error when closing deferredResponseWriter: %v", err)
+	}
+	res := mockResponseWriter.Result()
+	if res.StatusCode != http.StatusOK {
+		b.Fatalf("status code is not writtend properly, expected: 200, got: %d", res.StatusCode)
+	}
+}
+
+func BenchmarkChunkingGzip(b *testing.B) {
+	tests := []struct {
+		count int
+		size  int
+	}{
+		{
+			count: 100,
+			size:  1_000,
+		},
+		{
+			count: 100,
+			size:  100_000,
+		},
+		{
+			count: 1_000,
+			size:  100_000,
+		},
+		{
+			count: 1_000,
+			size:  1_000_000,
+		},
+		{
+			count: 10_000,
+			size:  100_000,
+		},
+		{
+			count: 100_000,
+			size:  10_000,
+		},
+		{
+			count: 1,
+			size:  100_000,
+		},
+		{
+			count: 1,
+			size:  1_000_000,
+		},
+		{
+			count: 1,
+			size:  10_000_000,
+		},
+		{
+			count: 1,
+			size:  100_000_000,
+		},
+		{
+			count: 1,
+			size:  1_000_000_000,
+		},
+	}
+
+	for _, t := range tests {
+		b.Run(fmt.Sprintf("Count=%d/Size=%d", t.count, t.size), func(b *testing.B) {
+			chunk := []byte(rand2.String(t.size))
+			benchmarkChunkingGzip(b, t.count, chunk)
 		})
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
@@ -39,8 +39,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testapigroupv1 "k8s.io/apimachinery/pkg/apis/testapigroup/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	rand2 "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apiserver/pkg/features"
@@ -806,4 +809,81 @@ func gzipContent(data []byte, level int) []byte {
 		panic(err)
 	}
 	return buf.Bytes()
+}
+
+func TestStreamingGzipIntegration(t *testing.T) {
+	largeChunk := bytes.Repeat([]byte("b"), defaultGzipThresholdBytes+1)
+	tcs := []struct {
+		name            string
+		serializer      runtime.Encoder
+		object          runtime.Object
+		expectGzip      bool
+		expectStreaming bool
+	}{
+		{
+			name:            "JSON, small object, default -> no gzip",
+			serializer:      jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, nil, nil, jsonserializer.SerializerOptions{}),
+			object:          &testapigroupv1.CarpList{},
+			expectGzip:      false,
+			expectStreaming: false,
+		},
+		{
+			name:            "JSON, small object, streaming -> no gzip",
+			serializer:      jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, nil, nil, jsonserializer.SerializerOptions{StreamingCollectionsEncoding: true}),
+			object:          &testapigroupv1.CarpList{},
+			expectGzip:      false,
+			expectStreaming: true,
+		},
+		{
+			name:            "JSON, large object, default -> gzip",
+			serializer:      jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, nil, nil, jsonserializer.SerializerOptions{}),
+			object:          &testapigroupv1.CarpList{TypeMeta: metav1.TypeMeta{Kind: string(largeChunk)}},
+			expectGzip:      true,
+			expectStreaming: false,
+		},
+		{
+			name:            "JSON, large object, streaming -> gzip",
+			serializer:      jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, nil, nil, jsonserializer.SerializerOptions{StreamingCollectionsEncoding: true}),
+			object:          &testapigroupv1.CarpList{TypeMeta: metav1.TypeMeta{Kind: string(largeChunk)}},
+			expectGzip:      true,
+			expectStreaming: true,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			mockResponseWriter := httptest.NewRecorder()
+			drw := &deferredResponseWriter{
+				mediaType:       "text/plain",
+				statusCode:      200,
+				contentEncoding: "gzip",
+				hw:              mockResponseWriter,
+				ctx:             context.Background(),
+			}
+			counter := &writeCounter{Writer: drw}
+			err := tc.serializer.Encode(tc.object, counter)
+			if err != nil {
+				t.Fatal(err)
+			}
+			encoding := mockResponseWriter.Header().Get("Content-Encoding")
+			if (encoding == "gzip") != tc.expectGzip {
+				t.Errorf("Expect gzip: %v, got: %q", tc.expectGzip, encoding)
+			}
+			if counter.writeCount < 1 {
+				t.Fatalf("Expect at least 1 write")
+			}
+			if (counter.writeCount > 1) != tc.expectStreaming {
+				t.Errorf("Expect streaming: %v, got write count: %d", tc.expectStreaming, counter.writeCount)
+			}
+		})
+	}
+}
+
+type writeCounter struct {
+	writeCount int
+	io.Writer
+}
+
+func (b *writeCounter) Write(data []byte) (int, error) {
+	b.writeCount++
+	return b.Writer.Write(data)
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
@@ -19,6 +19,7 @@ package responsewriters
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -32,6 +33,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -370,6 +372,124 @@ func TestSerializeObject(t *testing.T) {
 			if !bytes.Equal(tt.wantBody, body) {
 				t.Fatalf("wanted:\n%s\ngot:\n%s", hex.Dump(tt.wantBody), hex.Dump(body))
 			}
+		})
+	}
+}
+
+func TestDeferredResponseWriter_Write(t *testing.T) {
+	smallChunk := bytes.Repeat([]byte("b"), defaultGzipThresholdBytes-1)
+	largeChunk := bytes.Repeat([]byte("b"), defaultGzipThresholdBytes+1)
+
+	tests := []struct {
+		name       string
+		chunks     [][]byte
+		expectGzip bool
+	}{
+		{
+			name:       "one small chunk write",
+			chunks:     [][]byte{smallChunk},
+			expectGzip: false,
+		},
+		{
+			name:       "two small chunk writes",
+			chunks:     [][]byte{smallChunk, smallChunk},
+			expectGzip: false,
+		},
+		{
+			name:       "one large chunk writes",
+			chunks:     [][]byte{largeChunk},
+			expectGzip: true,
+		},
+		{
+			name:       "two large chunk writes",
+			chunks:     [][]byte{largeChunk, largeChunk},
+			expectGzip: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockResponseWriter := httptest.NewRecorder()
+
+			drw := &deferredResponseWriter{
+				mediaType:       "text/plain",
+				statusCode:      200,
+				contentEncoding: "gzip",
+				hw:              mockResponseWriter,
+				ctx:             context.Background(),
+			}
+
+			fullPayload := []byte{}
+
+			for _, chunk := range tt.chunks {
+				n, err := drw.Write(chunk)
+
+				if err != nil {
+					t.Fatalf("unexpected error while writing chunk: %v", err)
+				}
+				if n != len(chunk) {
+					t.Errorf("write is not complete, expected: %d bytes, written: %d bytes", len(chunk), n)
+				}
+
+				fullPayload = append(fullPayload, chunk...)
+			}
+
+			err := drw.Close()
+			if err != nil {
+				t.Fatalf("unexpected error when closing deferredResponseWriter: %v", err)
+			}
+
+			res := mockResponseWriter.Result()
+
+			if res.StatusCode != http.StatusOK {
+				t.Fatalf("status code is not writtend properly, expected: 200, got: %d", res.StatusCode)
+			}
+			contentEncoding := res.Header.Get("Content-Encoding")
+			varyHeader := res.Header.Get("Vary")
+
+			resBytes, err := io.ReadAll(res.Body)
+			if err != nil {
+				t.Fatalf("unexpected error occurred while reading response body: %v", err)
+			}
+
+			if tt.expectGzip {
+				if contentEncoding != "gzip" {
+					t.Fatalf("content-encoding is not set properly, expected: gzip, got: %s", contentEncoding)
+				}
+
+				if !strings.Contains(varyHeader, "Accept-Encoding") {
+					t.Errorf("vary header doesn't have Accept-Encoding")
+				}
+
+				gr, err := gzip.NewReader(bytes.NewReader(resBytes))
+				if err != nil {
+					t.Fatalf("failed to create gzip reader: %v", err)
+				}
+
+				decompressed, err := io.ReadAll(gr)
+				if err != nil {
+					t.Fatalf("failed to decompress: %v", err)
+				}
+
+				if !bytes.Equal(fullPayload, decompressed) {
+					t.Errorf("payload mismatch, expected: %s, got: %s", fullPayload, decompressed)
+				}
+
+			} else {
+				if contentEncoding != "" {
+					t.Errorf("content-encoding is set unexpectedly")
+				}
+
+				if strings.Contains(varyHeader, "Accept-Encoding") {
+					t.Errorf("accept encoding is set unexpectedly")
+				}
+
+				if !bytes.Equal(fullPayload, resBytes) {
+					t.Errorf("payload mismatch, expected: %s, got: %s", fullPayload, resBytes)
+				}
+
+			}
+
 		})
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -221,6 +221,10 @@ const (
 	// document.
 	StorageVersionHash featuregate.Feature = "StorageVersionHash"
 
+	// owner: @serathius
+	// Allow API server to encode collections item by item, instead of all at once.
+	StreamingCollectionEncodingToJSON featuregate.Feature = "StreamingCollectionEncodingToJSON"
+
 	// owner: @wojtek-t
 	// alpha: v1.15
 	// beta: v1.16
@@ -316,6 +320,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	WatchFromStorageWithoutResourceVersion: {Default: false, PreRelease: featuregate.Beta},
 
 	InPlacePodVerticalScaling: {Default: false, PreRelease: featuregate.Alpha},
+
+	StreamingCollectionEncodingToJSON: {Default: false, PreRelease: featuregate.Beta},
 
 	WatchList: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -949,6 +949,13 @@ func (s *GenericAPIServer) newAPIGroupVersion(apiGroupInfo *APIGroupInfo, groupV
 // NewDefaultAPIGroupInfo returns an APIGroupInfo stubbed with "normal" values
 // exposed for easier composition from other packages
 func NewDefaultAPIGroupInfo(group string, scheme *runtime.Scheme, parameterCodec runtime.ParameterCodec, codecs serializer.CodecFactory) APIGroupInfo {
+	opts := []serializer.CodecFactoryOptionsMutator{}
+	if utilfeature.DefaultFeatureGate.Enabled(features.StreamingCollectionEncodingToJSON) {
+		opts = append(opts, serializer.WithStreamingCollectionEncodingToJSON())
+	}
+	if len(opts) != 0 {
+		codecs = serializer.NewCodecFactory(scheme, opts...)
+	}
 	return APIGroupInfo{
 		PrioritizedVersions:          scheme.PrioritizedVersionsForGroup(group),
 		VersionedResourcesStorageMap: map[string]map[string]rest.Storage{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Reduce memory usage 
https://github.com/kubernetes/kubernetes/pull/129334#issuecomment-2692202272

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

NOTE: There are some adjustments because of conflict.

    * replace slice.Collect(maps.Key(*)) by mapsKeys method since there is
      no builtin iter.Seq in go1.20

    * versioned_kube_features.go doesn't exist in v1.28

    * v1.28 doesn't have StrictSerializer for CRD handler, so there is no
      new streaming option for that.
      staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go

    * In newSerializersForScheme, v1.28 doesn't have StrictSerializer so
      there is no new streaming option for that.
      staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go

    * Remove CBORServingAndStorage option when create codec_factory.
      staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go

    * Remove test/featuregates_linter/test_data/versioned_feature_list.yaml
      since it doesn't exist in v1.28

    * By default, this feature is disabled.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

