### PR TITLE
[exp-v1.30] backport streaming encoding feature

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -830,8 +830,12 @@ const (
 	StorageVersionMigrator featuregate.Feature = "StorageVersionMigrator"
 
 	// owner: @serathius
-	// Allow API server to encode collections item by item, instead of all at once.
+	// Allow API server JSON encoder to encode collections item by item, instead of all at once.
 	StreamingCollectionEncodingToJSON featuregate.Feature = "StreamingCollectionEncodingToJSON"
+
+	// owner: serathius
+	// Allow API server Protobuf encoder to encode collections item by item, instead of all at once.
+	StreamingCollectionEncodingToProtobuf featuregate.Feature = "StreamingCollectionEncodingToProtobuf"
 
 	// owner: @robscott
 	// kep: https://kep.k8s.io/2433

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -829,6 +829,10 @@ const (
 	// Enables support for the StorageVersionMigrator controller.
 	StorageVersionMigrator featuregate.Feature = "StorageVersionMigrator"
 
+	// owner: @serathius
+	// Allow API server to encode collections item by item, instead of all at once.
+	StreamingCollectionEncodingToJSON featuregate.Feature = "StreamingCollectionEncodingToJSON"
+
 	// owner: @robscott
 	// kep: https://kep.k8s.io/2433
 	// alpha: v1.21

--- a/pkg/registry/core/rest/storage_core_generic.go
+++ b/pkg/registry/core/rest/storage_core_generic.go
@@ -76,6 +76,9 @@ func (c *GenericConfig) NewRESTStorage(apiResourceConfigSource serverstorage.API
 	if utilfeature.DefaultFeatureGate.Enabled(features.StreamingCollectionEncodingToJSON) {
 		opts = append(opts, serializer.WithStreamingCollectionEncodingToJSON())
 	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.StreamingCollectionEncodingToProtobuf) {
+		opts = append(opts, serializer.WithStreamingCollectionEncodingToProtobuf())
+	}
 	if len(opts) != 0 {
 		apiGroupInfo.NegotiatedSerializer = serializer.NewCodecFactory(legacyscheme.Scheme, opts...)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -888,7 +888,9 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 					MediaType:        "application/vnd.kubernetes.protobuf",
 					MediaTypeType:    "application",
 					MediaTypeSubType: "vnd.kubernetes.protobuf",
-					Serializer:       protobuf.NewSerializer(creator, typer),
+					Serializer: protobuf.NewSerializerWithOptions(creator, typer, protobuf.SerializerOptions{
+						StreamingCollectionsEncoding: utilfeature.DefaultFeatureGate.Enabled(features.StreamingCollectionEncodingToProtobuf),
+					}),
 					StreamSerializer: &runtime.StreamSerializerInfo{
 						Serializer: protobuf.NewRawSerializer(creator, typer),
 						Framer:     protobuf.LengthDelimitedFramer,
@@ -962,6 +964,9 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 		var opts []serializer.CodecFactoryOptionsMutator
 		if utilfeature.DefaultFeatureGate.Enabled(features.StreamingCollectionEncodingToJSON) {
 			opts = append(opts, serializer.WithStreamingCollectionEncodingToJSON())
+		}
+		if utilfeature.DefaultFeatureGate.Enabled(features.StreamingCollectionEncodingToProtobuf) {
+			opts = append(opts, serializer.WithStreamingCollectionEncodingToProtobuf())
 		}
 		scaleScope.Serializer = serializer.NewCodecFactory(scaleConverter.Scheme(), opts...)
 		scaleScope.Kind = autoscalingv1.SchemeGroupVersion.WithKind("Scale")

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/crdserverscheme"
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource"
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor"
+	"k8s.io/kubernetes/pkg/features"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -71,6 +72,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericfilters "k8s.io/apiserver/pkg/server/filters"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/util/webhook"
 	"k8s.io/apiserver/pkg/warning"
 	"k8s.io/client-go/scale"
@@ -845,6 +847,7 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 		clusterScoped := crd.Spec.Scope == apiextensionsv1.ClusterScoped
 
 		// CRDs explicitly do not support protobuf, but some objects returned by the API server do
+		streamingCollections := utilfeature.DefaultFeatureGate.Enabled(features.StreamingCollectionEncodingToJSON)
 		negotiatedSerializer := unstructuredNegotiatedSerializer{
 			typer:                 typer,
 			creator:               creator,
@@ -858,10 +861,11 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 					MediaTypeType:    "application",
 					MediaTypeSubType: "json",
 					EncodesAsText:    true,
-					Serializer:       json.NewSerializer(json.DefaultMetaFactory, creator, typer, false),
-					PrettySerializer: json.NewSerializer(json.DefaultMetaFactory, creator, typer, true),
+					Serializer:       json.NewSerializerWithOptions(json.DefaultMetaFactory, creator, typer, json.SerializerOptions{StreamingCollectionsEncoding: streamingCollections}),
+					PrettySerializer: json.NewSerializerWithOptions(json.DefaultMetaFactory, creator, typer, json.SerializerOptions{Pretty: true}),
 					StrictSerializer: json.NewSerializerWithOptions(json.DefaultMetaFactory, creator, typer, json.SerializerOptions{
-						Strict: true,
+						Strict:                       true,
+						StreamingCollectionsEncoding: streamingCollections,
 					}),
 					StreamSerializer: &runtime.StreamSerializerInfo{
 						EncodesAsText: true,
@@ -955,7 +959,11 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 		scaleScope := *requestScopes[v.Name]
 		scaleConverter := scale.NewScaleConverter()
 		scaleScope.Subresource = "scale"
-		scaleScope.Serializer = serializer.NewCodecFactory(scaleConverter.Scheme())
+		var opts []serializer.CodecFactoryOptionsMutator
+		if utilfeature.DefaultFeatureGate.Enabled(features.StreamingCollectionEncodingToJSON) {
+			opts = append(opts, serializer.WithStreamingCollectionEncodingToJSON())
+		}
+		scaleScope.Serializer = serializer.NewCodecFactory(scaleConverter.Scheme(), opts...)
 		scaleScope.Kind = autoscalingv1.SchemeGroupVersion.WithKind("Scale")
 		scaleScope.Namer = handlers.ContextBasedNaming{
 			Namer:         meta.NewAccessor(),

--- a/staging/src/k8s.io/apimachinery/go.mod
+++ b/staging/src/k8s.io/apimachinery/go.mod
@@ -55,6 +55,7 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	sigs.k8s.io/randfill v1.0.0 // indirect
 )
 
 replace k8s.io/apimachinery => ../apimachinery

--- a/staging/src/k8s.io/apimachinery/go.sum
+++ b/staging/src/k8s.io/apimachinery/go.sum
@@ -160,6 +160,8 @@ k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSn
 k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
+sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
+sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/help.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/help.go
@@ -221,6 +221,9 @@ func extractList(obj runtime.Object, allocNew bool) ([]runtime.Object, error) {
 	if err != nil {
 		return nil, err
 	}
+	if items.IsNil() {
+		return nil, nil
+	}
 	list := make([]runtime.Object, items.Len())
 	if len(list) == 0 {
 		return list, nil

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
@@ -52,7 +52,7 @@ type serializerType struct {
 func newSerializersForScheme(scheme *runtime.Scheme, mf json.MetaFactory, options CodecFactoryOptions) []serializerType {
 	jsonSerializer := json.NewSerializerWithOptions(
 		mf, scheme, scheme,
-		json.SerializerOptions{Yaml: false, Pretty: false, Strict: options.Strict},
+		json.SerializerOptions{Yaml: false, Pretty: false, Strict: options.Strict, StreamingCollectionsEncoding: options.StreamingCollectionsEncodingToJSON},
 	)
 	jsonSerializerType := serializerType{
 		AcceptContentTypes: []string{runtime.ContentTypeJSON},
@@ -136,6 +136,8 @@ type CodecFactoryOptions struct {
 	Strict bool
 	// Pretty includes a pretty serializer along with the non-pretty one
 	Pretty bool
+
+	StreamingCollectionsEncodingToJSON bool
 }
 
 // CodecFactoryOptionsMutator takes a pointer to an options struct and then modifies it.
@@ -160,6 +162,12 @@ func EnableStrict(options *CodecFactoryOptions) {
 // DisableStrict disables configuring all serializers in strict mode
 func DisableStrict(options *CodecFactoryOptions) {
 	options.Strict = false
+}
+
+func WithStreamingCollectionEncodingToJSON() CodecFactoryOptionsMutator {
+	return func(options *CodecFactoryOptions) {
+		options.StreamingCollectionsEncodingToJSON = true
+	}
 }
 
 // NewCodecFactory provides methods for retrieving serializers for the supported wire formats

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_factory.go
@@ -85,7 +85,9 @@ func newSerializersForScheme(scheme *runtime.Scheme, mf json.MetaFactory, option
 		mf, scheme, scheme,
 		json.SerializerOptions{Yaml: true, Pretty: false, Strict: true},
 	)
-	protoSerializer := protobuf.NewSerializer(scheme, scheme)
+	protoSerializer := protobuf.NewSerializerWithOptions(scheme, scheme, protobuf.SerializerOptions{
+		StreamingCollectionsEncoding: options.StreamingCollectionsEncodingToProtobuf,
+	})
 	protoRawSerializer := protobuf.NewRawSerializer(scheme, scheme)
 
 	serializers := []serializerType{
@@ -137,7 +139,8 @@ type CodecFactoryOptions struct {
 	// Pretty includes a pretty serializer along with the non-pretty one
 	Pretty bool
 
-	StreamingCollectionsEncodingToJSON bool
+	StreamingCollectionsEncodingToJSON     bool
+	StreamingCollectionsEncodingToProtobuf bool
 }
 
 // CodecFactoryOptionsMutator takes a pointer to an options struct and then modifies it.
@@ -167,6 +170,12 @@ func DisableStrict(options *CodecFactoryOptions) {
 func WithStreamingCollectionEncodingToJSON() CodecFactoryOptionsMutator {
 	return func(options *CodecFactoryOptions) {
 		options.StreamingCollectionsEncodingToJSON = true
+	}
+}
+
+func WithStreamingCollectionEncodingToProtobuf() CodecFactoryOptionsMutator {
+	return func(options *CodecFactoryOptions) {
+		options.StreamingCollectionsEncodingToProtobuf = true
 	}
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package json
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"slices"
+	"sort"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/conversion"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func streamEncodeCollections(obj runtime.Object, w io.Writer) (bool, error) {
+	list, ok := obj.(*unstructured.UnstructuredList)
+	if ok {
+		return true, streamingEncodeUnstructuredList(w, list)
+	}
+	if _, ok := obj.(json.Marshaler); ok {
+		return false, nil
+	}
+	typeMeta, listMeta, items, err := getListMeta(obj)
+	if err == nil {
+		return true, streamingEncodeList(w, typeMeta, listMeta, items)
+	}
+	return false, nil
+}
+
+// getListMeta implements list extraction logic for json stream serialization.
+//
+// Reason for a custom logic instead of reusing accessors from meta package:
+// * Validate json tags to prevent incompatibility with json standard package.
+// * ListMetaAccessor doesn't distinguish empty from nil value.
+// * TypeAccessort reparsing "apiVersion" and serializing it with "{group}/{version}"
+func getListMeta(list runtime.Object) (metav1.TypeMeta, metav1.ListMeta, []runtime.Object, error) {
+	listValue, err := conversion.EnforcePtr(list)
+	if err != nil {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, err
+	}
+	listType := listValue.Type()
+	if listType.NumField() != 3 {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf("expected ListType to have 3 fields")
+	}
+	// TypeMeta
+	typeMeta, ok := listValue.Field(0).Interface().(metav1.TypeMeta)
+	if !ok {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf("expected TypeMeta field to have TypeMeta type")
+	}
+	if listType.Field(0).Tag.Get("json") != ",inline" {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf(`expected TypeMeta json field tag to be ",inline"`)
+	}
+	// ListMeta
+	listMeta, ok := listValue.Field(1).Interface().(metav1.ListMeta)
+	if !ok {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf("expected ListMeta field to have ListMeta type")
+	}
+	if listType.Field(1).Tag.Get("json") != "metadata,omitempty" {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf(`expected ListMeta json field tag to be "metadata,omitempty"`)
+	}
+	// Items
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, err
+	}
+	if listType.Field(2).Tag.Get("json") != "items" {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf(`expected Items json field tag to be "items"`)
+	}
+	return typeMeta, listMeta, items, nil
+}
+
+func streamingEncodeList(w io.Writer, typeMeta metav1.TypeMeta, listMeta metav1.ListMeta, items []runtime.Object) error {
+	// Start
+	if _, err := w.Write([]byte(`{`)); err != nil {
+		return err
+	}
+
+	// TypeMeta
+	if typeMeta.Kind != "" {
+		if err := encodeKeyValuePair(w, "kind", typeMeta.Kind, []byte(",")); err != nil {
+			return err
+		}
+	}
+	if typeMeta.APIVersion != "" {
+		if err := encodeKeyValuePair(w, "apiVersion", typeMeta.APIVersion, []byte(",")); err != nil {
+			return err
+		}
+	}
+
+	// ListMeta
+	if err := encodeKeyValuePair(w, "metadata", listMeta, []byte(",")); err != nil {
+		return err
+	}
+
+	// Items
+	if err := encodeItemsObjectSlice(w, items); err != nil {
+		return err
+	}
+
+	// End
+	_, err := w.Write([]byte("}\n"))
+	return err
+}
+
+func encodeItemsObjectSlice(w io.Writer, items []runtime.Object) (err error) {
+	if items == nil {
+		err := encodeKeyValuePair(w, "items", nil, nil)
+		return err
+	}
+	_, err = w.Write([]byte(`"items":[`))
+	if err != nil {
+		return err
+	}
+	suffix := []byte(",")
+	for i, item := range items {
+		if i == len(items)-1 {
+			suffix = nil
+		}
+		err := encodeValue(w, item, suffix)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = w.Write([]byte("]"))
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func streamingEncodeUnstructuredList(w io.Writer, list *unstructured.UnstructuredList) error {
+	_, err := w.Write([]byte(`{`))
+	if err != nil {
+		return err
+	}
+	keys := slices.Collect(maps.Keys(list.Object))
+	if _, exists := list.Object["items"]; !exists {
+		keys = append(keys, "items")
+	}
+	sort.Strings(keys)
+
+	suffix := []byte(",")
+	for i, key := range keys {
+		if i == len(keys)-1 {
+			suffix = nil
+		}
+		if key == "items" {
+			err = encodeItemsUnstructuredSlice(w, list.Items, suffix)
+		} else {
+			err = encodeKeyValuePair(w, key, list.Object[key], suffix)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	_, err = w.Write([]byte("}\n"))
+	return err
+}
+
+func encodeItemsUnstructuredSlice(w io.Writer, items []unstructured.Unstructured, suffix []byte) (err error) {
+	_, err = w.Write([]byte(`"items":[`))
+	if err != nil {
+		return err
+	}
+	comma := []byte(",")
+	for i, item := range items {
+		if i == len(items)-1 {
+			comma = nil
+		}
+		err := encodeValue(w, item.Object, comma)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = w.Write([]byte("]"))
+	if err != nil {
+		return err
+	}
+	if len(suffix) > 0 {
+		_, err = w.Write(suffix)
+	}
+	return err
+}
+
+func encodeKeyValuePair(w io.Writer, key string, value any, suffix []byte) (err error) {
+	err = encodeValue(w, key, []byte(":"))
+	if err != nil {
+		return err
+	}
+	err = encodeValue(w, value, suffix)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func encodeValue(w io.Writer, value any, suffix []byte) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	if err != nil {
+		return err
+	}
+	if len(suffix) > 0 {
+		_, err = w.Write(suffix)
+	}
+	return err
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections_test.go
@@ -1,0 +1,655 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package json
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	testapigroupv1 "k8s.io/apimachinery/pkg/apis/testapigroup/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestCollectionsEncoding(t *testing.T) {
+	t.Run("Normal", func(t *testing.T) {
+		testCollectionsEncoding(t, NewSerializerWithOptions(DefaultMetaFactory, nil, nil, SerializerOptions{}))
+	})
+	// Leave place for testing streaming collection serializer proposed as part of KEP-5116
+}
+
+// testCollectionsEncoding should provide comprehensive tests to validate streaming implementation of encoder.
+func testCollectionsEncoding(t *testing.T, s *Serializer) {
+	var buf bytes.Buffer
+	var remainingItems int64 = 1
+	// As defined in KEP-5116 we it should include the following scenarios:
+	// Context: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5116-streaming-response-encoding#unit-tests
+	for _, tc := range []struct {
+		name   string
+		in     runtime.Object
+		expect string
+	}{
+		// Preserving the distinction between integers and floating-point numbers
+		{
+			name: "Struct with floats",
+			in: &StructWithFloatsList{
+				Items: []StructWithFloats{
+					{
+						Int:     1,
+						Float32: float32(1),
+						Float64: 1.1,
+					},
+				},
+			},
+			expect: "{\"metadata\":{},\"items\":[{\"metadata\":{\"creationTimestamp\":null},\"Int\":1,\"Float32\":1,\"Float64\":1.1}]}\n",
+		},
+		{
+			name: "Unstructured object float",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"int":     1,
+					"float32": float32(1),
+					"float64": 1.1,
+				},
+			},
+			expect: "{\"float32\":1,\"float64\":1.1,\"int\":1,\"items\":[]}\n",
+		},
+		{
+			name: "Unstructured items float",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"int":     1,
+							"float32": float32(1),
+							"float64": 1.1,
+						},
+					},
+				},
+			},
+			expect: "{\"items\":[{\"float32\":1,\"float64\":1.1,\"int\":1}]}\n",
+		},
+		// Handling structs with duplicate field names (JSON tag names) without producing duplicate keys in the encoded output
+		{
+			name: "StructWithDuplicatedTags",
+			in: &StructWithDuplicatedTagsList{
+				Items: []StructWithDuplicatedTags{
+					{
+						Key1: "key1",
+						Key2: "key2",
+					},
+				},
+			},
+			expect: "{\"metadata\":{},\"items\":[{\"metadata\":{\"creationTimestamp\":null}}]}\n",
+		},
+		// Encoding Go strings containing invalid UTF-8 sequences without error
+		{
+			name: "UnstructuredList object invalid UTF-8 ",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"key": "\x80", // first byte is a continuation byte
+				},
+			},
+			expect: "{\"items\":[],\"key\":\"\\ufffd\"}\n",
+		},
+		{
+			name: "UnstructuredList items invalid UTF-8 ",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"key": "\x80", // first byte is a continuation byte
+						},
+					},
+				},
+			},
+			expect: "{\"items\":[{\"key\":\"\\ufffd\"}]}\n",
+		},
+		// Preserving the distinction between absent, present-but-null, and present-and-empty states for slices and maps
+		{
+			name: "CarpList items nil",
+			in: &testapigroupv1.CarpList{
+				Items: nil,
+			},
+			expect: "{\"metadata\":{},\"items\":null}\n",
+		},
+		{
+			name: "CarpList slice nil",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{
+					{
+						Status: testapigroupv1.CarpStatus{
+							Conditions: nil,
+						},
+					},
+				},
+			},
+			expect: "{\"metadata\":{},\"items\":[{\"metadata\":{\"creationTimestamp\":null},\"spec\":{},\"status\":{}}]}\n",
+		},
+		{
+			name: "CarpList map nil",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{
+					{
+						Spec: testapigroupv1.CarpSpec{
+							NodeSelector: nil,
+						},
+					},
+				},
+			},
+			expect: "{\"metadata\":{},\"items\":[{\"metadata\":{\"creationTimestamp\":null},\"spec\":{},\"status\":{}}]}\n",
+		},
+		{
+			name: "UnstructuredList items nil",
+			in: &unstructured.UnstructuredList{
+				Items: nil,
+			},
+			expect: "{\"items\":[]}\n",
+		},
+		{
+			name: "UnstructuredList items slice nil",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"slice": ([]string)(nil),
+						},
+					},
+				},
+			},
+			expect: "{\"items\":[{\"slice\":null}]}\n",
+		},
+		{
+			name: "UnstructuredList items map nil",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"map": (map[string]string)(nil),
+						},
+					},
+				},
+			},
+			expect: "{\"items\":[{\"map\":null}]}\n",
+		},
+		{
+			name: "UnstructuredList object nil",
+			in: &unstructured.UnstructuredList{
+				Object: nil,
+			},
+			expect: "{\"items\":[]}\n",
+		},
+		{
+			name: "UnstructuredList object slice nil",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"slice": ([]string)(nil),
+				},
+			},
+			expect: "{\"items\":[],\"slice\":null}\n",
+		},
+		{
+			name: "UnstructuredList object map nil",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"map": (map[string]string)(nil),
+				},
+			},
+			expect: "{\"items\":[],\"map\":null}\n",
+		},
+		{
+			name: "CarpList items empty",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{},
+			},
+			expect: "{\"metadata\":{},\"items\":[]}\n",
+		},
+		{
+			name: "CarpList slice empty",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{
+					{
+						Status: testapigroupv1.CarpStatus{
+							Conditions: []testapigroupv1.CarpCondition{},
+						},
+					},
+				},
+			},
+			expect: "{\"metadata\":{},\"items\":[{\"metadata\":{\"creationTimestamp\":null},\"spec\":{},\"status\":{}}]}\n",
+		},
+		{
+			name: "CarpList map empty",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{
+					{
+						Spec: testapigroupv1.CarpSpec{
+							NodeSelector: map[string]string{},
+						},
+					},
+				},
+			},
+			expect: "{\"metadata\":{},\"items\":[{\"metadata\":{\"creationTimestamp\":null},\"spec\":{},\"status\":{}}]}\n",
+		},
+		{
+			name: "UnstructuredList items empty",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{},
+			},
+			expect: "{\"items\":[]}\n",
+		},
+		{
+			name: "UnstructuredList items slice empty",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"slice": []string{},
+						},
+					},
+				},
+			},
+			expect: "{\"items\":[{\"slice\":[]}]}\n",
+		},
+		{
+			name: "UnstructuredList items map empty",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"map": map[string]string{},
+						},
+					},
+				},
+			},
+			expect: "{\"items\":[{\"map\":{}}]}\n",
+		},
+		{
+			name: "UnstructuredList object empty",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{},
+			},
+			expect: "{\"items\":[]}\n",
+		},
+		{
+			name: "UnstructuredList object slice empty",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"slice": []string{},
+				},
+			},
+			expect: "{\"items\":[],\"slice\":[]}\n",
+		},
+		{
+			name: "UnstructuredList object map empty",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"map": map[string]string{},
+				},
+			},
+			expect: "{\"items\":[],\"map\":{}}\n",
+		},
+		// Handling structs implementing MarshallJSON method, especially built-in collection types.
+		{
+			name:   "List with MarshallJSON",
+			in:     &ListWithMarshalJSONList{},
+			expect: "\"marshallJSON\"\n",
+		},
+		{
+			name: "Struct with MarshallJSON",
+			in: &StructWithMarshalJSONList{
+				Items: []StructWithMarshalJSON{
+					{},
+				},
+			},
+			expect: "{\"metadata\":{},\"items\":[\"marshallJSON\"]}\n",
+		},
+		// Handling raw bytes.
+		{
+			name: "Struct with raw bytes",
+			in: &StructWithRawBytesList{
+				Items: []StructWithRawBytes{
+					{
+						Slice: []byte{0x01, 0x02, 0x03},
+						Array: [3]byte{0x01, 0x02, 0x03},
+					},
+				},
+			},
+			expect: "{\"metadata\":{},\"items\":[{\"metadata\":{\"creationTimestamp\":null},\"Slice\":\"AQID\",\"Array\":[1,2,3]}]}\n",
+		},
+		{
+			name: "UnstructuredList object raw bytes",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"slice": []byte{0x01, 0x02, 0x03},
+					"array": [3]byte{0x01, 0x02, 0x03},
+				},
+			},
+			expect: "{\"array\":[1,2,3],\"items\":[],\"slice\":\"AQID\"}\n",
+		},
+		{
+			name: "UnstructuredList items raw bytes",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"slice": []byte{0x01, 0x02, 0x03},
+							"array": [3]byte{0x01, 0x02, 0x03},
+						},
+					},
+				},
+			},
+			expect: "{\"items\":[{\"array\":[1,2,3],\"slice\":\"AQID\"}]}\n",
+		},
+		// Other scenarios:
+		{
+			name: "List just kind",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "List",
+				},
+			},
+			expect: "{\"kind\":\"List\",\"metadata\":{},\"items\":null}\n",
+		},
+		{
+			name: "List just apiVersion",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+			},
+			expect: "{\"apiVersion\":\"v1\",\"metadata\":{},\"items\":null}\n",
+		},
+		{
+			name: "List no elements",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+				ListMeta: metav1.ListMeta{
+					ResourceVersion: "2345",
+				},
+				Items: []testapigroupv1.Carp{},
+			},
+			expect: "{\"kind\":\"List\",\"apiVersion\":\"v1\",\"metadata\":{\"resourceVersion\":\"2345\"},\"items\":[]}\n",
+		},
+		{
+			name: "List one element with continue",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+				ListMeta: metav1.ListMeta{
+					ResourceVersion:    "2345",
+					Continue:           "abc",
+					RemainingItemCount: &remainingItems,
+				},
+				Items: []testapigroupv1.Carp{
+					{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod",
+						Namespace: "default",
+					}},
+				},
+			},
+			expect: "{\"kind\":\"List\",\"apiVersion\":\"v1\",\"metadata\":{\"resourceVersion\":\"2345\",\"continue\":\"abc\",\"remainingItemCount\":1},\"items\":[{\"kind\":\"Carp\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"pod\",\"namespace\":\"default\",\"creationTimestamp\":null},\"spec\":{},\"status\":{}}]}\n",
+		},
+		{
+			name: "List two elements",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+				ListMeta: metav1.ListMeta{
+					ResourceVersion: "2345",
+				},
+				Items: []testapigroupv1.Carp{
+					{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod",
+						Namespace: "default",
+					}},
+					{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod2",
+						Namespace: "default2",
+					}},
+				},
+			},
+			expect: `{"kind":"List","apiVersion":"v1","metadata":{"resourceVersion":"2345"},"items":[{"kind":"Carp","apiVersion":"v1","metadata":{"name":"pod","namespace":"default","creationTimestamp":null},"spec":{},"status":{}},{"kind":"Carp","apiVersion":"v1","metadata":{"name":"pod2","namespace":"default2","creationTimestamp":null},"spec":{},"status":{}}]}
+`,
+		},
+		{
+			name:   "UnstructuredList empty",
+			in:     &unstructured.UnstructuredList{},
+			expect: "{\"items\":[]}\n",
+		},
+		{
+			name: "UnstructuredList just kind",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"kind": "List"},
+			},
+			expect: "{\"items\":[],\"kind\":\"List\"}\n",
+		},
+		{
+			name: "UnstructuredList just apiVersion",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"apiVersion": "v1"},
+			},
+			expect: "{\"apiVersion\":\"v1\",\"items\":[]}\n",
+		},
+		{
+			name: "UnstructuredList no elements",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{"resourceVersion": "2345"}},
+				Items:  []unstructured.Unstructured{},
+			},
+			expect: "{\"apiVersion\":\"v1\",\"items\":[],\"kind\":\"List\",\"metadata\":{\"resourceVersion\":\"2345\"}}\n",
+		},
+		{
+			name: "UnstructuredList one element with continue",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{
+					"resourceVersion":    "2345",
+					"continue":           "abc",
+					"remainingItemCount": "1",
+				}},
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "Carp",
+							"metadata": map[string]interface{}{
+								"name":      "pod",
+								"namespace": "default",
+							},
+						},
+					},
+				},
+			},
+			expect: "{\"apiVersion\":\"v1\",\"items\":[{\"apiVersion\":\"v1\",\"kind\":\"Carp\",\"metadata\":{\"name\":\"pod\",\"namespace\":\"default\"}}],\"kind\":\"List\",\"metadata\":{\"continue\":\"abc\",\"remainingItemCount\":\"1\",\"resourceVersion\":\"2345\"}}\n",
+		},
+		{
+			name: "UnstructuredList two elements",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{
+					"resourceVersion": "2345",
+				}},
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "Carp",
+							"metadata": map[string]interface{}{
+								"name":      "pod",
+								"namespace": "default",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "Carp",
+							"metadata": map[string]interface{}{
+								"name":      "pod2",
+								"namespace": "default",
+							},
+						},
+					},
+				},
+			},
+			expect: "{\"apiVersion\":\"v1\",\"items\":[{\"apiVersion\":\"v1\",\"kind\":\"Carp\",\"metadata\":{\"name\":\"pod\",\"namespace\":\"default\"}},{\"apiVersion\":\"v1\",\"kind\":\"Carp\",\"metadata\":{\"name\":\"pod2\",\"namespace\":\"default\"}}],\"kind\":\"List\",\"metadata\":{\"resourceVersion\":\"2345\"}}\n",
+		},
+		{
+			name: "UnstructuredList conflict on items",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"items": []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"name": "pod",
+						},
+					},
+				},
+				},
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"name": "pod2",
+						},
+					},
+				},
+			},
+			expect: "{\"items\":[{\"name\":\"pod2\"}]}\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			buf.Reset()
+			if err := s.Encode(tc.in, &buf); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			t.Logf("normal: %s", buf.String())
+			if diff := cmp.Diff(buf.String(), tc.expect); diff != "" {
+				t.Errorf("not matching:\n%s", diff)
+			}
+		})
+	}
+}
+
+type StructWithFloatsList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []StructWithFloats `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (l *StructWithFloatsList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type StructWithFloats struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	Int     int
+	Float32 float32
+	Float64 float64
+}
+
+func (s *StructWithFloats) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type StructWithDuplicatedTagsList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []StructWithDuplicatedTags `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (l *StructWithDuplicatedTagsList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type StructWithDuplicatedTags struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	Key1 string `json:"key"`
+	Key2 string `json:"key"` //nolint:govet
+}
+
+func (s *StructWithDuplicatedTags) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type ListWithMarshalJSONList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []string `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (l *ListWithMarshalJSONList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+func (l *ListWithMarshalJSONList) MarshalJSON() ([]byte, error) {
+	return []byte(`"marshallJSON"`), nil
+}
+
+type StructWithMarshalJSONList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []StructWithMarshalJSON `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (s *StructWithMarshalJSONList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type StructWithMarshalJSON struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+}
+
+func (l *StructWithMarshalJSON) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+func (l *StructWithMarshalJSON) MarshalJSON() ([]byte, error) {
+	return []byte(`"marshallJSON"`), nil
+}
+
+type StructWithRawBytesList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []StructWithRawBytes `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (s *StructWithRawBytesList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type StructWithRawBytes struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Slice             []byte
+	Array             [3]byte
+}
+
+func (s *StructWithRawBytes) DeepCopyObject() runtime.Object {
+	return nil
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections_test.go
@@ -18,9 +18,11 @@ package json
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	fuzz "github.com/google/gofuzz"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -30,21 +32,24 @@ import (
 
 func TestCollectionsEncoding(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
-		testCollectionsEncoding(t, NewSerializerWithOptions(DefaultMetaFactory, nil, nil, SerializerOptions{}))
+		testCollectionsEncoding(t, NewSerializerWithOptions(DefaultMetaFactory, nil, nil, SerializerOptions{}), false)
 	})
-	// Leave place for testing streaming collection serializer proposed as part of KEP-5116
+	t.Run("Streaming", func(t *testing.T) {
+		testCollectionsEncoding(t, NewSerializerWithOptions(DefaultMetaFactory, nil, nil, SerializerOptions{StreamingCollectionsEncoding: true}), true)
+	})
 }
 
 // testCollectionsEncoding should provide comprehensive tests to validate streaming implementation of encoder.
-func testCollectionsEncoding(t *testing.T, s *Serializer) {
-	var buf bytes.Buffer
+func testCollectionsEncoding(t *testing.T, s *Serializer, streamingEnabled bool) {
+	var buf writeCountingBuffer
 	var remainingItems int64 = 1
 	// As defined in KEP-5116 we it should include the following scenarios:
 	// Context: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5116-streaming-response-encoding#unit-tests
 	for _, tc := range []struct {
-		name   string
-		in     runtime.Object
-		expect string
+		name         string
+		in           runtime.Object
+		cannotStream bool
+		expect       string
 	}{
 		// Preserving the distinction between integers and floating-point numbers
 		{
@@ -307,9 +312,10 @@ func testCollectionsEncoding(t *testing.T, s *Serializer) {
 		},
 		// Handling structs implementing MarshallJSON method, especially built-in collection types.
 		{
-			name:   "List with MarshallJSON",
-			in:     &ListWithMarshalJSONList{},
-			expect: "\"marshallJSON\"\n",
+			name:         "List with MarshallJSON cannot be streamed",
+			in:           &ListWithMarshalJSONList{},
+			expect:       "\"marshallJSON\"\n",
+			cannotStream: true,
 		},
 		{
 			name: "Struct with MarshallJSON",
@@ -436,6 +442,32 @@ func testCollectionsEncoding(t *testing.T, s *Serializer) {
 `,
 		},
 		{
+			name: "List with extra field cannot be streamed",
+			in: &ListWithAdditionalFields{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+				ListMeta: metav1.ListMeta{
+					ResourceVersion: "2345",
+				},
+				Items: []testapigroupv1.Carp{},
+			},
+			cannotStream: true,
+			expect:       "{\"kind\":\"List\",\"apiVersion\":\"v1\",\"metadata\":{\"resourceVersion\":\"2345\"},\"items\":[],\"AdditionalField\":0}\n",
+		},
+		{
+			name: "Not a collection cannot be streamed",
+			in: &testapigroupv1.Carp{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+			},
+			cannotStream: true,
+			expect:       "{\"kind\":\"List\",\"apiVersion\":\"v1\",\"metadata\":{\"creationTimestamp\":null},\"spec\":{},\"status\":{}}\n",
+		},
+		{
 			name:   "UnstructuredList empty",
 			in:     &unstructured.UnstructuredList{},
 			expect: "{\"items\":[]}\n",
@@ -543,9 +575,16 @@ func testCollectionsEncoding(t *testing.T, s *Serializer) {
 			if err := s.Encode(tc.in, &buf); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			t.Logf("normal: %s", buf.String())
+			t.Logf("encoded: %s", buf.String())
 			if diff := cmp.Diff(buf.String(), tc.expect); diff != "" {
 				t.Errorf("not matching:\n%s", diff)
+			}
+			expectStreaming := !tc.cannotStream && streamingEnabled
+			if expectStreaming && buf.writeCount <= 1 {
+				t.Errorf("expected streaming but Write was called only: %d", buf.writeCount)
+			}
+			if !expectStreaming && buf.writeCount > 1 {
+				t.Errorf("expected non-streaming but Write was called more than once: %d", buf.writeCount)
 			}
 		})
 	}
@@ -652,4 +691,104 @@ type StructWithRawBytes struct {
 
 func (s *StructWithRawBytes) DeepCopyObject() runtime.Object {
 	return nil
+}
+
+type ListWithAdditionalFields struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []testapigroupv1.Carp `json:"items" protobuf:"bytes,2,rep,name=items"`
+	AdditionalField int
+}
+
+func (s *ListWithAdditionalFields) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type writeCountingBuffer struct {
+	writeCount int
+	bytes.Buffer
+}
+
+func (b *writeCountingBuffer) Write(data []byte) (int, error) {
+	b.writeCount++
+	return b.Buffer.Write(data)
+}
+
+func (b *writeCountingBuffer) Reset() {
+	b.writeCount = 0
+	b.Buffer.Reset()
+}
+
+func TestFuzzCollectionsEncoding(t *testing.T) {
+	disableFuzzFieldsV1 := func(field *metav1.FieldsV1, c fuzz.Continue) {}
+	fuzzUnstructuredList := func(list *unstructured.UnstructuredList, c fuzz.Continue) {
+		list.Object = map[string]interface{}{
+			"kind":         "List",
+			"apiVersion":   "v1",
+			c.RandString(): c.RandString(),
+			c.RandString(): c.RandUint64(),
+			c.RandString(): c.RandBool(),
+			"metadata": map[string]interface{}{
+				"resourceVersion":    fmt.Sprintf("%d", c.RandUint64()),
+				"continue":           c.RandString(),
+				"remainingItemCount": fmt.Sprintf("%d", c.RandUint64()),
+				c.RandString():       c.RandString(),
+			}}
+		c.Fuzz(&list.Items)
+	}
+	fuzzMap := func(kvs map[string]interface{}, c fuzz.Continue) {
+		kvs[c.RandString()] = c.RandBool()
+		kvs[c.RandString()] = c.RandUint64()
+		kvs[c.RandString()] = c.RandString()
+	}
+	f := fuzz.New().Funcs(disableFuzzFieldsV1, fuzzUnstructuredList, fuzzMap)
+	streamingBuffer := &bytes.Buffer{}
+	normalSerializer := NewSerializerWithOptions(DefaultMetaFactory, nil, nil, SerializerOptions{StreamingCollectionsEncoding: false})
+	normalBuffer := &bytes.Buffer{}
+	t.Run("CarpList", func(t *testing.T) {
+		for i := 0; i < 1000; i++ {
+			list := &testapigroupv1.CarpList{}
+			f.Fuzz(list)
+			streamingBuffer.Reset()
+			normalBuffer.Reset()
+			ok, err := streamEncodeCollections(list, streamingBuffer)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !ok {
+				t.Fatalf("expected streaming encoder to encode %T", list)
+			}
+			if err := normalSerializer.Encode(list, normalBuffer); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(normalBuffer.String(), streamingBuffer.String()); diff != "" {
+				t.Logf("normal: %s", normalBuffer.String())
+				t.Logf("streaming: %s", streamingBuffer.String())
+				t.Errorf("not matching:\n%s", diff)
+			}
+		}
+	})
+	t.Run("UnstructuredList", func(t *testing.T) {
+		for i := 0; i < 1000; i++ {
+			list := &unstructured.UnstructuredList{}
+			f.Fuzz(list)
+			streamingBuffer.Reset()
+			normalBuffer.Reset()
+			ok, err := streamEncodeCollections(list, streamingBuffer)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !ok {
+				t.Fatalf("expected streaming encoder to encode %T", list)
+			}
+			if err := normalSerializer.Encode(list, normalBuffer); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(normalBuffer.String(), streamingBuffer.String()); diff != "" {
+				t.Logf("normal: %s", normalBuffer.String())
+				t.Logf("streaming: %s", streamingBuffer.String())
+				t.Errorf("not matching:\n%s", diff)
+			}
+		}
+	})
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/collections.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/collections.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protobuf
+
+import (
+	"errors"
+	"io"
+	"math/bits"
+
+	"github.com/gogo/protobuf/proto"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	errFieldCount          = errors.New("expected ListType to have 3 fields")
+	errTypeMetaField       = errors.New("expected TypeMeta field to have TypeMeta type")
+	errTypeMetaProtobufTag = errors.New(`expected TypeMeta protobuf field tag to be ""`)
+	errListMetaField       = errors.New("expected ListMeta field to have ListMeta type")
+	errListMetaProtobufTag = errors.New(`expected ListMeta protobuf field tag to be "bytes,1,opt,name=metadata"`)
+	errItemsProtobufTag    = errors.New(`expected Items protobuf field tag to be "bytes,2,rep,name=items"`)
+	errItemsSizer          = errors.New(`expected Items elements to implement proto.Sizer`)
+)
+
+// getStreamingListData implements list extraction logic for protobuf stream serialization.
+//
+// Reason for a custom logic instead of reusing accessors from meta package:
+// * Validate proto tags to prevent incompatibility with proto standard package.
+// * ListMetaAccessor doesn't distinguish empty from nil value.
+// * TypeAccessor reparsing "apiVersion" and serializing it with "{group}/{version}"
+func getStreamingListData(list runtime.Object) (data streamingListData, err error) {
+	listValue, err := conversion.EnforcePtr(list)
+	if err != nil {
+		return data, err
+	}
+	listType := listValue.Type()
+	if listType.NumField() != 3 {
+		return data, errFieldCount
+	}
+	// TypeMeta: validated, but not returned as is not serialized.
+	_, ok := listValue.Field(0).Interface().(metav1.TypeMeta)
+	if !ok {
+		return data, errTypeMetaField
+	}
+	if listType.Field(0).Tag.Get("protobuf") != "" {
+		return data, errTypeMetaProtobufTag
+	}
+	// ListMeta
+	listMeta, ok := listValue.Field(1).Interface().(metav1.ListMeta)
+	if !ok {
+		return data, errListMetaField
+	}
+	// if we were ever to relax the protobuf tag check we should update the hardcoded `0xa` below when writing ListMeta.
+	if listType.Field(1).Tag.Get("protobuf") != "bytes,1,opt,name=metadata" {
+		return data, errListMetaProtobufTag
+	}
+	data.listMeta = listMeta
+	// Items; if we were ever to relax the protobuf tag check we should update the hardcoded `0x12` below when writing Items.
+	if listType.Field(2).Tag.Get("protobuf") != "bytes,2,rep,name=items" {
+		return data, errItemsProtobufTag
+	}
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return data, err
+	}
+	data.items = items
+	data.totalSize, data.listMetaSize, data.itemsSizes, err = listSize(listMeta, items)
+	return data, err
+}
+
+type streamingListData struct {
+	// totalSize is the total size of the serialized List object, including their proto headers/size bytes
+	totalSize int
+
+	// listMetaSize caches results from .Size() call to listMeta, doesn't include header bytes (field identifier, size)
+	listMetaSize int
+	listMeta     metav1.ListMeta
+
+	// itemsSizes caches results from .Size() call to items, doesn't include header bytes (field identifier, size)
+	itemsSizes []int
+	items      []runtime.Object
+}
+
+// listSize return size of ListMeta and items to be later used for preallocations.
+// listMetaSize and itemSizes do not include header bytes (field identifier, size).
+func listSize(listMeta metav1.ListMeta, items []runtime.Object) (totalSize, listMetaSize int, itemSizes []int, err error) {
+	// ListMeta
+	listMetaSize = listMeta.Size()
+	totalSize += 1 + sovGenerated(uint64(listMetaSize)) + listMetaSize
+	// Items
+	itemSizes = make([]int, len(items))
+	for i, item := range items {
+		sizer, ok := item.(proto.Sizer)
+		if !ok {
+			return totalSize, listMetaSize, nil, errItemsSizer
+		}
+		n := sizer.Size()
+		itemSizes[i] = n
+		totalSize += 1 + sovGenerated(uint64(n)) + n
+	}
+	return totalSize, listMetaSize, itemSizes, nil
+}
+
+func streamingEncodeUnknownList(w io.Writer, unk runtime.Unknown, listData streamingListData, memAlloc runtime.MemoryAllocator) error {
+	_, err := w.Write(protoEncodingPrefix)
+	if err != nil {
+		return err
+	}
+	// encodeList is responsible for encoding the List into the unknown Raw.
+	encodeList := func(writer io.Writer) (int, error) {
+		return streamingEncodeList(writer, listData, memAlloc)
+	}
+	_, err = unk.MarshalToWriter(w, listData.totalSize, encodeList)
+	return err
+}
+
+func streamingEncodeList(w io.Writer, listData streamingListData, memAlloc runtime.MemoryAllocator) (size int, err error) {
+	// ListMeta; 0xa = (1 << 3) | 2; field number: 1, type: 2 (LEN). https://protobuf.dev/programming-guides/encoding/#structure
+	n, err := doEncodeWithHeader(&listData.listMeta, w, 0xa, listData.listMetaSize, memAlloc)
+	size += n
+	if err != nil {
+		return size, err
+	}
+	// Items; 0x12 = (2 << 3) | 2; field number: 2, type: 2 (LEN). https://protobuf.dev/programming-guides/encoding/#structure
+	for i, item := range listData.items {
+		n, err := doEncodeWithHeader(item, w, 0x12, listData.itemsSizes[i], memAlloc)
+		size += n
+		if err != nil {
+			return size, err
+		}
+	}
+	return size, nil
+}
+
+func writeVarintGenerated(w io.Writer, v int) (int, error) {
+	buf := make([]byte, sovGenerated(uint64(v)))
+	encodeVarintGenerated(buf, len(buf), uint64(v))
+	return w.Write(buf)
+}
+
+// sovGenerated is copied from `generated.pb.go` returns size of varint.
+func sovGenerated(v uint64) int {
+	return (bits.Len64(v|1) + 6) / 7
+}
+
+// encodeVarintGenerated is copied from `generated.pb.go` encodes varint.
+func encodeVarintGenerated(dAtA []byte, offset int, v uint64) int {
+	offset -= sovGenerated(v)
+	base := offset
+	for v >= 1<<7 {
+		dAtA[offset] = uint8(v&0x7f | 0x80)
+		v >>= 7
+		offset++
+	}
+	dAtA[offset] = uint8(v)
+	return base
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/collections_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/collections_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protobuf
+
+import (
+	"bytes"
+	"encoding/base64"
+	"io"
+	"os/exec"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testapigroupv1 "k8s.io/apimachinery/pkg/apis/testapigroup/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestCollectionsEncoding(t *testing.T) {
+	t.Run("Normal", func(t *testing.T) {
+		testCollectionsEncoding(t, NewSerializer(nil, nil))
+	})
+	// Leave place for testing streaming collection serializer proposed as part of KEP-5116
+}
+
+func testCollectionsEncoding(t *testing.T, s *Serializer) {
+	var remainingItems int64 = 1
+	testCases := []struct {
+		name string
+		in   runtime.Object
+		// expect is base64 encoded protobuf bytes
+		expect string
+	}{
+		{
+			name: "CarpList items nil",
+			in: &testapigroupv1.CarpList{
+				Items: nil,
+			},
+			expect: "azhzAAoECgASABIICgYKABIAGgAaACIA",
+		},
+		{
+			name: "CarpList slice nil",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{
+					{
+						Status: testapigroupv1.CarpStatus{
+							Conditions: nil,
+						},
+					},
+				},
+			},
+			expect: "azhzAAoECgASABJBCgYKABIAGgASNwoQCgASABoAIgAqADIAOABCABIXGgBCAEoAUgBYAGAAaACCAQCKAQCaAQAaCgoAGgAiACoAMgAaACIA",
+		},
+		{
+			name: "CarpList map nil",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{
+					{
+						Spec: testapigroupv1.CarpSpec{
+							NodeSelector: nil,
+						},
+					},
+				},
+			},
+			expect: "azhzAAoECgASABJBCgYKABIAGgASNwoQCgASABoAIgAqADIAOABCABIXGgBCAEoAUgBYAGAAaACCAQCKAQCaAQAaCgoAGgAiACoAMgAaACIA",
+		},
+		{
+			name: "CarpList items empty",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{},
+			},
+			expect: "azhzAAoECgASABIICgYKABIAGgAaACIA",
+		},
+		{
+			name: "CarpList slice empty",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{
+					{
+						Status: testapigroupv1.CarpStatus{
+							Conditions: []testapigroupv1.CarpCondition{},
+						},
+					},
+				},
+			},
+			expect: "azhzAAoECgASABJBCgYKABIAGgASNwoQCgASABoAIgAqADIAOABCABIXGgBCAEoAUgBYAGAAaACCAQCKAQCaAQAaCgoAGgAiACoAMgAaACIA",
+		},
+		{
+			name: "CarpList map empty",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{
+					{
+						Spec: testapigroupv1.CarpSpec{
+							NodeSelector: map[string]string{},
+						},
+					},
+				},
+			},
+			expect: "azhzAAoECgASABJBCgYKABIAGgASNwoQCgASABoAIgAqADIAOABCABIXGgBCAEoAUgBYAGAAaACCAQCKAQCaAQAaCgoAGgAiACoAMgAaACIA",
+		},
+		{
+			name: "List just kind",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "List",
+				},
+			},
+			expect: "azhzAAoICgASBExpc3QSCAoGCgASABoAGgAiAA==",
+		},
+		{
+			name: "List just apiVersion",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+			},
+			expect: "azhzAAoGCgJ2MRIAEggKBgoAEgAaABoAIgA=",
+		},
+		{
+			name: "List no elements",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+				ListMeta: metav1.ListMeta{
+					ResourceVersion: "2345",
+				},
+				Items: []testapigroupv1.Carp{},
+			},
+			expect: "azhzAAoKCgJ2MRIETGlzdBIMCgoKABIEMjM0NRoAGgAiAA==",
+		},
+		{
+			name: "List one element with continue",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+				ListMeta: metav1.ListMeta{
+					ResourceVersion:    "2345",
+					Continue:           "abc",
+					RemainingItemCount: &remainingItems,
+				},
+				Items: []testapigroupv1.Carp{
+					{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod",
+						Namespace: "default",
+					}},
+				},
+			},
+			expect: "azhzAAoKCgJ2MRIETGlzdBJUCg8KABIEMjM0NRoDYWJjIAESQQoaCgNwb2QSABoHZGVmYXVsdCIAKgAyADgAQgASFxoAQgBKAFIAWABgAGgAggEAigEAmgEAGgoKABoAIgAqADIAGgAiAA==",
+		},
+		{
+			name: "List two elements",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+				ListMeta: metav1.ListMeta{
+					ResourceVersion: "2345",
+				},
+				Items: []testapigroupv1.Carp{
+					{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod",
+						Namespace: "default",
+					}},
+					{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod2",
+						Namespace: "default2",
+					}},
+				},
+			},
+			expect: "azhzAAoKCgJ2MRIETGlzdBKUAQoKCgASBDIzNDUaABJBChoKA3BvZBIAGgdkZWZhdWx0IgAqADIAOABCABIXGgBCAEoAUgBYAGAAaACCAQCKAQCaAQAaCgoAGgAiACoAMgASQwocCgRwb2QyEgAaCGRlZmF1bHQyIgAqADIAOABCABIXGgBCAEoAUgBYAGAAaACCAQCKAQCaAQAaCgoAGgAiACoAMgAaACIA",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := s.Encode(tc.in, &buf); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			actualBytes := buf.Bytes()
+			expectBytes, err := io.ReadAll(base64.NewDecoder(base64.StdEncoding, bytes.NewBufferString(tc.expect)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(expectBytes, actualBytes) {
+				t.Errorf("expected:\n%s\ngot:\n%s", tc.expect, base64.StdEncoding.EncodeToString(actualBytes))
+				t.Log(cmp.Diff(dumpProto(t, actualBytes[4:]), dumpProto(t, expectBytes[4:])))
+			}
+		})
+	}
+}
+
+// dumpProto does a best-effort dump of the given proto bytes using protoc if it can be found in the path.
+// This is only used when the test has already failed, to try to give more visibility into the diff of the failure.
+func dumpProto(t *testing.T, data []byte) string {
+	t.Helper()
+	protoc, err := exec.LookPath("protoc")
+	if err != nil {
+		t.Logf("cannot find protoc in path to dump proto contents: %v", err)
+		return ""
+	}
+	cmd := exec.Command(protoc, "--decode_raw")
+	cmd.Stdin = bytes.NewBuffer(data)
+	d, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("protoc invocation failed: %v", err)
+		return ""
+	}
+	return string(d)
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
@@ -72,10 +72,18 @@ func IsNotMarshalable(err error) bool {
 // is passed, the encoded object will have group, version, and kind fields set. If typer is nil, the objects will be written
 // as-is (any type info passed with the object will be used).
 func NewSerializer(creater runtime.ObjectCreater, typer runtime.ObjectTyper) *Serializer {
+	return NewSerializerWithOptions(creater, typer, SerializerOptions{})
+}
+
+// NewSerializerWithOptions creates a Protobuf serializer that handles encoding versioned objects into the proper wire form. If a typer
+// is passed, the encoded object will have group, version, and kind fields set. If typer is nil, the objects will be written
+// as-is (any type info passed with the object will be used).
+func NewSerializerWithOptions(creater runtime.ObjectCreater, typer runtime.ObjectTyper, opts SerializerOptions) *Serializer {
 	return &Serializer{
 		prefix:  protoEncodingPrefix,
 		creater: creater,
 		typer:   typer,
+		options: opts,
 	}
 }
 
@@ -84,6 +92,14 @@ type Serializer struct {
 	prefix  []byte
 	creater runtime.ObjectCreater
 	typer   runtime.ObjectTyper
+
+	options SerializerOptions
+}
+
+// SerializerOptions holds the options which are used to configure a Proto serializer.
+type SerializerOptions struct {
+	// StreamingCollectionsEncoding enables encoding collection, one item at the time, drastically reducing memory needed.
+	StreamingCollectionsEncoding bool
 }
 
 var _ runtime.Serializer = &Serializer{}
@@ -207,6 +223,13 @@ func (s *Serializer) doEncode(obj runtime.Object, w io.Writer, memAlloc runtime.
 				Kind:       kind.Kind,
 				APIVersion: kind.GroupVersion().String(),
 			},
+		}
+	}
+	if s.options.StreamingCollectionsEncoding {
+		listData, err := getStreamingListData(obj)
+		if err == nil {
+			// Doesn't honor custom proto marshaling methods (like json streaming), because all proto objects implement proto methods.
+			return streamingEncodeUnknownList(w, unk, listData, memAlloc)
 		}
 	}
 
@@ -428,6 +451,39 @@ func (s *RawSerializer) encode(obj runtime.Object, w io.Writer, memAlloc runtime
 }
 
 func (s *RawSerializer) doEncode(obj runtime.Object, w io.Writer, memAlloc runtime.MemoryAllocator) error {
+	_, err := doEncode(obj, w, nil, memAlloc)
+	return err
+}
+
+func doEncodeWithHeader(obj any, w io.Writer, field byte, precomputedSize int, memAlloc runtime.MemoryAllocator) (size int, err error) {
+	// Field identifier
+	n, err := w.Write([]byte{field})
+	size += n
+	if err != nil {
+		return size, err
+	}
+	// Size
+	n, err = writeVarintGenerated(w, precomputedSize)
+	size += n
+	if err != nil {
+		return size, err
+	}
+	// Obj
+	n, err = doEncode(obj, w, &precomputedSize, memAlloc)
+	size += n
+	if err != nil {
+		return size, err
+	}
+	if n != precomputedSize {
+		return size, fmt.Errorf("the size value was %d, but doEncode wrote %d bytes to data", precomputedSize, n)
+	}
+	return size, nil
+}
+
+// doEncode encodes provided object into writer using a allocator if possible.
+// Avoids call by object Size if precomputedObjSize is provided.
+// precomputedObjSize should not include header bytes (field identifier, size).
+func doEncode(obj any, w io.Writer, precomputedObjSize *int, memAlloc runtime.MemoryAllocator) (int, error) {
 	if memAlloc == nil {
 		klog.Error("a mandatory memory allocator wasn't provided, this might have a negative impact on performance, check invocations of EncodeWithAllocator method, falling back on runtime.SimpleAllocator")
 		memAlloc = &runtime.SimpleAllocator{}
@@ -436,40 +492,43 @@ func (s *RawSerializer) doEncode(obj runtime.Object, w io.Writer, memAlloc runti
 	case bufferedReverseMarshaller:
 		// this path performs a single allocation during write only when the Allocator wasn't provided
 		// it also requires the caller to implement the more efficient Size and MarshalToSizedBuffer methods
-		encodedSize := uint64(t.Size())
-		data := memAlloc.Allocate(encodedSize)
+		if precomputedObjSize == nil {
+			s := t.Size()
+			precomputedObjSize = &s
+		}
+		data := memAlloc.Allocate(uint64(*precomputedObjSize))
 
 		n, err := t.MarshalToSizedBuffer(data)
 		if err != nil {
-			return err
+			return 0, err
 		}
-		_, err = w.Write(data[:n])
-		return err
+		return w.Write(data[:n])
 
 	case bufferedMarshaller:
 		// this path performs a single allocation during write only when the Allocator wasn't provided
 		// it also requires the caller to implement the more efficient Size and MarshalTo methods
-		encodedSize := uint64(t.Size())
-		data := memAlloc.Allocate(encodedSize)
+		if precomputedObjSize == nil {
+			s := t.Size()
+			precomputedObjSize = &s
+		}
+		data := memAlloc.Allocate(uint64(*precomputedObjSize))
 
 		n, err := t.MarshalTo(data)
 		if err != nil {
-			return err
+			return 0, err
 		}
-		_, err = w.Write(data[:n])
-		return err
+		return w.Write(data[:n])
 
 	case proto.Marshaler:
 		// this path performs extra allocations
 		data, err := t.Marshal()
 		if err != nil {
-			return err
+			return 0, err
 		}
-		_, err = w.Write(data)
-		return err
+		return w.Write(data)
 
 	default:
-		return errNotMarshalable{reflect.TypeOf(obj)}
+		return 0, errNotMarshalable{reflect.TypeOf(obj)}
 	}
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/types_proto.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/types_proto.go
@@ -18,6 +18,7 @@ package runtime
 
 import (
 	"fmt"
+	"io"
 )
 
 type ProtobufMarshaller interface {
@@ -26,6 +27,124 @@ type ProtobufMarshaller interface {
 
 type ProtobufReverseMarshaller interface {
 	MarshalToSizedBuffer(data []byte) (int, error)
+}
+
+const (
+	typeMetaTag        = 0xa
+	rawTag             = 0x12
+	contentEncodingTag = 0x1a
+	contentTypeTag     = 0x22
+
+	// max length of a varint for a uint64
+	maxUint64VarIntLength = 10
+)
+
+// MarshalToWriter allows a caller to provide a streaming writer for raw bytes,
+// instead of populating them inside the Unknown struct.
+// rawSize is the number of bytes rawWriter will write in a success case.
+// writeRaw is called when it is time to write the raw bytes. It must return `rawSize, nil` or an error.
+func (m *Unknown) MarshalToWriter(w io.Writer, rawSize int, writeRaw func(io.Writer) (int, error)) (int, error) {
+	size := 0
+
+	// reuse the buffer for varint marshaling
+	varintBuffer := make([]byte, maxUint64VarIntLength)
+	writeVarint := func(i int) (int, error) {
+		offset := encodeVarintGenerated(varintBuffer, len(varintBuffer), uint64(i))
+		return w.Write(varintBuffer[offset:])
+	}
+
+	// TypeMeta
+	{
+		n, err := w.Write([]byte{typeMetaTag})
+		size += n
+		if err != nil {
+			return size, err
+		}
+
+		typeMetaBytes, err := m.TypeMeta.Marshal()
+		if err != nil {
+			return size, err
+		}
+
+		n, err = writeVarint(len(typeMetaBytes))
+		size += n
+		if err != nil {
+			return size, err
+		}
+
+		n, err = w.Write(typeMetaBytes)
+		size += n
+		if err != nil {
+			return size, err
+		}
+	}
+
+	// Raw, delegating write to writeRaw()
+	{
+		n, err := w.Write([]byte{rawTag})
+		size += n
+		if err != nil {
+			return size, err
+		}
+
+		n, err = writeVarint(rawSize)
+		size += n
+		if err != nil {
+			return size, err
+		}
+
+		n, err = writeRaw(w)
+		size += n
+		if err != nil {
+			return size, err
+		}
+		if n != int(rawSize) {
+			return size, fmt.Errorf("the size value was %d, but encoding wrote %d bytes to data", rawSize, n)
+		}
+	}
+
+	// ContentEncoding
+	{
+		n, err := w.Write([]byte{contentEncodingTag})
+		size += n
+		if err != nil {
+			return size, err
+		}
+
+		n, err = writeVarint(len(m.ContentEncoding))
+		size += n
+		if err != nil {
+			return size, err
+		}
+
+		n, err = w.Write([]byte(m.ContentEncoding))
+		size += n
+		if err != nil {
+			return size, err
+		}
+	}
+
+	// ContentEncoding
+	{
+		n, err := w.Write([]byte{contentTypeTag})
+		size += n
+		if err != nil {
+			return size, err
+		}
+
+		n, err = writeVarint(len(m.ContentType))
+		size += n
+		if err != nil {
+			return size, err
+		}
+
+		n, err = w.Write([]byte(m.ContentType))
+		size += n
+		if err != nil {
+			return size, err
+		}
+	}
+	return size, nil
 }
 
 // NestedMarshalTo allows a caller to avoid extra allocations during serialization of an Unknown
@@ -43,12 +162,12 @@ func (m *Unknown) NestedMarshalTo(data []byte, b ProtobufMarshaller, size uint64
 	copy(data[i:], m.ContentType)
 	i = encodeVarintGenerated(data, i, uint64(len(m.ContentType)))
 	i--
-	data[i] = 0x22
+	data[i] = contentTypeTag
 	i -= len(m.ContentEncoding)
 	copy(data[i:], m.ContentEncoding)
 	i = encodeVarintGenerated(data, i, uint64(len(m.ContentEncoding)))
 	i--
-	data[i] = 0x1a
+	data[i] = contentEncodingTag
 	if b != nil {
 		if r, ok := b.(ProtobufReverseMarshaller); ok {
 			n1, err := r.MarshalToSizedBuffer(data[:i])
@@ -75,7 +194,7 @@ func (m *Unknown) NestedMarshalTo(data []byte, b ProtobufMarshaller, size uint64
 		}
 		i = encodeVarintGenerated(data, i, size)
 		i--
-		data[i] = 0x12
+		data[i] = rawTag
 	}
 	n2, err := m.TypeMeta.MarshalToSizedBuffer(data[:i])
 	if err != nil {
@@ -84,6 +203,6 @@ func (m *Unknown) NestedMarshalTo(data []byte, b ProtobufMarshaller, size uint64
 	i -= n2
 	i = encodeVarintGenerated(data, i, uint64(n2))
 	i--
-	data[i] = 0xa
+	data[i] = typeMetaTag
 	return msgSize - i, nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/types_proto_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/types_proto_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"bytes"
+	"io"
+	"math"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestVarint(t *testing.T) {
+	varintBuffer := make([]byte, maxUint64VarIntLength)
+	offset := encodeVarintGenerated(varintBuffer, len(varintBuffer), math.MaxUint64)
+	used := len(varintBuffer) - offset
+	if used != maxUint64VarIntLength {
+		t.Fatalf("expected encodeVarintGenerated to use %d bytes to encode MaxUint64, got %d", maxUint64VarIntLength, used)
+	}
+}
+
+func TestNestedMarshalToWriter(t *testing.T) {
+	testcases := []struct {
+		name string
+		raw  []byte
+	}{
+		{
+			name: "zero-length",
+			raw:  []byte{},
+		},
+		{
+			name: "simple",
+			raw:  []byte{0x00, 0x01, 0x02, 0x03},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			u := &Unknown{
+				ContentType:     "ct",
+				ContentEncoding: "ce",
+				TypeMeta: TypeMeta{
+					APIVersion: "v1",
+					Kind:       "k",
+				},
+			}
+
+			// Marshal normally with Raw inlined
+			u.Raw = tc.raw
+			marshalData, err := u.Marshal()
+			if err != nil {
+				t.Fatal(err)
+			}
+			u.Raw = nil
+
+			// Marshal with NestedMarshalTo
+			nestedMarshalData := make([]byte, len(marshalData))
+			n, err := u.NestedMarshalTo(nestedMarshalData, copyMarshaler(tc.raw), uint64(len(tc.raw)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n != len(marshalData) {
+				t.Errorf("NestedMarshalTo returned %d, expected %d", n, len(marshalData))
+			}
+			if e, a := marshalData, nestedMarshalData; !bytes.Equal(e, a) {
+				t.Errorf("NestedMarshalTo and Marshal differ:\n%s", cmp.Diff(e, a))
+			}
+
+			// Streaming marshal with MarshalToWriter
+			buf := bytes.NewBuffer(nil)
+			n, err = u.MarshalToWriter(buf, len(tc.raw), func(w io.Writer) (int, error) {
+				return w.Write(tc.raw)
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n != len(marshalData) {
+				t.Errorf("MarshalToWriter returned %d, expected %d", n, len(marshalData))
+			}
+			if e, a := marshalData, buf.Bytes(); !bytes.Equal(e, a) {
+				t.Errorf("MarshalToWriter and Marshal differ:\n%s", cmp.Diff(e, a))
+			}
+		})
+	}
+}
+
+type copyMarshaler []byte
+
+func (c copyMarshaler) MarshalTo(dest []byte) (int, error) {
+	n := copy(dest, []byte(c))
+	return n, nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -199,6 +199,10 @@ type deferredResponseWriter struct {
 	hasWritten  bool
 	hw          http.ResponseWriter
 	w           io.Writer
+	// totalBytes is the number of bytes written to `w` and does not include buffered bytes
+	totalBytes int
+	// lastWriteErr holds the error result (if any) of the last write attempt to `w`
+	lastWriteErr error
 
 	ctx context.Context
 }
@@ -241,26 +245,11 @@ func (w *deferredResponseWriter) Write(p []byte) (n int, err error) {
 }
 
 func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
-	ctx := w.ctx
-	span := tracing.SpanFromContext(ctx)
-	// This Step usually wraps in-memory object serialization.
-	span.AddEvent("About to start writing response", attribute.Int("size", len(p)))
-
-	firstWrite := !w.hasWritten
 	defer func() {
-		if err != nil {
-			span.AddEvent("Write call failed",
-				attribute.String("writer", fmt.Sprintf("%T", w.w)),
-				attribute.Int("size", len(p)),
-				attribute.Bool("firstWrite", firstWrite),
-				attribute.String("err", err.Error()))
-		} else {
-			span.AddEvent("Write call succeeded",
-				attribute.String("writer", fmt.Sprintf("%T", w.w)),
-				attribute.Int("size", len(p)),
-				attribute.Bool("firstWrite", firstWrite))
-		}
+		w.totalBytes += n
+		w.lastWriteErr = err
 	}()
+
 	if w.hasWritten {
 		return w.w.Write(p)
 	}
@@ -281,12 +270,35 @@ func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
 		w.w = hw
 	}
 
+	span := tracing.SpanFromContext(w.ctx)
+	span.AddEvent("About to start writing response",
+		attribute.String("writer", fmt.Sprintf("%T", w.w)),
+		attribute.Int("size", len(p)),
+	)
+
 	header.Set("Content-Type", w.mediaType)
 	hw.WriteHeader(w.statusCode)
 	return w.w.Write(p)
 }
 
 func (w *deferredResponseWriter) Close() (err error) {
+	defer func() {
+		if !w.hasWritten {
+			return
+		}
+
+		span := tracing.SpanFromContext(w.ctx)
+
+		if w.lastWriteErr != nil {
+			span.AddEvent("Write call failed",
+				attribute.Int("size", w.totalBytes),
+				attribute.String("err", w.lastWriteErr.Error()))
+		} else {
+			span.AddEvent("Write call succeeded",
+				attribute.Int("size", w.totalBytes))
+		}
+	}()
+
 	if !w.hasWritten {
 		if !w.hasBuffered {
 			return nil

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -156,9 +156,9 @@ const (
 	// (usually the entire object), and if the size is smaller no gzipping will be performed
 	// if the client requests it.
 	defaultGzipThresholdBytes = 128 * 1024
-	// Use the length of the first write of streaming implementations.
-	// TODO: Update when streaming proto is implemented
-	firstWriteStreamingThresholdBytes = 1
+	// Use the length of the first write to recognize streaming implementations.
+	// When streaming JSON first write is "{", while Kubernetes protobuf starts unique 4 byte header.
+	firstWriteStreamingThresholdBytes = 4
 )
 
 // negotiateContentEncoding returns a supported client-requested content encoding for the

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -156,6 +156,9 @@ const (
 	// (usually the entire object), and if the size is smaller no gzipping will be performed
 	// if the client requests it.
 	defaultGzipThresholdBytes = 128 * 1024
+	// Use the length of the first write of streaming implementations.
+	// TODO: Update when streaming proto is implemented
+	firstWriteStreamingThresholdBytes = 1
 )
 
 // negotiateContentEncoding returns a supported client-requested content encoding for the
@@ -191,14 +194,53 @@ type deferredResponseWriter struct {
 	statusCode      int
 	contentEncoding string
 
-	hasWritten bool
-	hw         http.ResponseWriter
-	w          io.Writer
+	hasBuffered bool
+	buffer      []byte
+	hasWritten  bool
+	hw          http.ResponseWriter
+	w           io.Writer
 
 	ctx context.Context
 }
 
 func (w *deferredResponseWriter) Write(p []byte) (n int, err error) {
+	switch {
+	case w.hasWritten:
+		// already written, cannot buffer
+		return w.unbufferedWrite(p)
+
+	case w.contentEncoding != "gzip":
+		// non-gzip, no need to buffer
+		return w.unbufferedWrite(p)
+
+	case !w.hasBuffered && len(p) > defaultGzipThresholdBytes:
+		// not yet buffered, first write is long enough to trigger gzip, no need to buffer
+		return w.unbufferedWrite(p)
+
+	case !w.hasBuffered && len(p) > firstWriteStreamingThresholdBytes:
+		// not yet buffered, first write is longer than expected for streaming scenarios that would require buffering, no need to buffer
+		return w.unbufferedWrite(p)
+
+	default:
+		if !w.hasBuffered {
+			w.hasBuffered = true
+			// Start at 80 bytes to avoid rapid reallocation of the buffer.
+			// The minimum size of a 0-item serialized list object is 80 bytes:
+			// {"kind":"List","apiVersion":"v1","metadata":{"resourceVersion":"1"},"items":[]}\n
+			w.buffer = make([]byte, 0, max(80, len(p)))
+		}
+		w.buffer = append(w.buffer, p...)
+		var err error
+		if len(w.buffer) > defaultGzipThresholdBytes {
+			// we've accumulated enough to trigger gzip, write and clear buffer
+			_, err = w.unbufferedWrite(w.buffer)
+			w.buffer = nil
+		}
+		return len(p), err
+	}
+}
+
+func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
 	ctx := w.ctx
 	span := tracing.SpanFromContext(ctx)
 	// This Step usually wraps in-memory object serialization.
@@ -244,11 +286,17 @@ func (w *deferredResponseWriter) Write(p []byte) (n int, err error) {
 	return w.w.Write(p)
 }
 
-func (w *deferredResponseWriter) Close() error {
+func (w *deferredResponseWriter) Close() (err error) {
 	if !w.hasWritten {
-		return nil
+		if !w.hasBuffered {
+			return nil
+		}
+		// never reached defaultGzipThresholdBytes, no need to do the gzip writer cleanup
+		_, err := w.unbufferedWrite(w.buffer)
+		w.buffer = nil
+		return err
 	}
-	var err error
+
 	switch t := w.w.(type) {
 	case *gzip.Writer:
 		err = t.Close()

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/runtime/serializer/protobuf"
 	rand2 "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apiserver/pkg/features"
@@ -841,6 +842,34 @@ func TestStreamingGzipIntegration(t *testing.T) {
 		{
 			name:            "JSON, large object, streaming -> gzip",
 			serializer:      jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, nil, nil, jsonserializer.SerializerOptions{StreamingCollectionsEncoding: true}),
+			object:          &testapigroupv1.CarpList{TypeMeta: metav1.TypeMeta{Kind: string(largeChunk)}},
+			expectGzip:      true,
+			expectStreaming: true,
+		},
+		{
+			name:            "Protobuf, small object, default -> no gzip",
+			serializer:      protobuf.NewSerializerWithOptions(nil, nil, protobuf.SerializerOptions{}),
+			object:          &testapigroupv1.CarpList{},
+			expectGzip:      false,
+			expectStreaming: false,
+		},
+		{
+			name:            "Protobuf, small object, streaming -> no gzip",
+			serializer:      protobuf.NewSerializerWithOptions(nil, nil, protobuf.SerializerOptions{StreamingCollectionsEncoding: true}),
+			object:          &testapigroupv1.CarpList{},
+			expectGzip:      false,
+			expectStreaming: true,
+		},
+		{
+			name:            "Protobuf, large object, default -> gzip",
+			serializer:      protobuf.NewSerializerWithOptions(nil, nil, protobuf.SerializerOptions{}),
+			object:          &testapigroupv1.CarpList{TypeMeta: metav1.TypeMeta{Kind: string(largeChunk)}},
+			expectGzip:      true,
+			expectStreaming: false,
+		},
+		{
+			name:            "Protobuf, large object, streaming -> gzip",
+			serializer:      protobuf.NewSerializerWithOptions(nil, nil, protobuf.SerializerOptions{StreamingCollectionsEncoding: true}),
 			object:          &testapigroupv1.CarpList{TypeMeta: metav1.TypeMeta{Kind: string(largeChunk)}},
 			expectGzip:      true,
 			expectStreaming: true,

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -253,8 +253,12 @@ const (
 	StorageVersionHash featuregate.Feature = "StorageVersionHash"
 
 	// owner: @serathius
-	// Allow API server to encode collections item by item, instead of all at once.
+	// Allow API server JSON encoder to encode collections item by item, instead of all at once.
 	StreamingCollectionEncodingToJSON featuregate.Feature = "StreamingCollectionEncodingToJSON"
+
+	// owner: @serathius
+	// Allow API server Protobuf encoder to encode collections item by item, instead of all at once.
+	StreamingCollectionEncodingToProtobuf featuregate.Feature = "StreamingCollectionEncodingToProtobuf"
 
 	// owner: @aramase, @enj, @nabokihms
 	// kep: https://kep.k8s.io/3331
@@ -378,6 +382,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	StructuredAuthorizationConfiguration: {Default: true, PreRelease: featuregate.Beta},
 
 	StreamingCollectionEncodingToJSON: {Default: false, PreRelease: featuregate.Beta},
+
+	StreamingCollectionEncodingToProtobuf: {Default: false, PreRelease: featuregate.Beta},
 
 	UnauthenticatedHTTP2DOSMitigation: {Default: true, PreRelease: featuregate.Beta},
 

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -252,6 +252,10 @@ const (
 	// document.
 	StorageVersionHash featuregate.Feature = "StorageVersionHash"
 
+	// owner: @serathius
+	// Allow API server to encode collections item by item, instead of all at once.
+	StreamingCollectionEncodingToJSON featuregate.Feature = "StreamingCollectionEncodingToJSON"
+
 	// owner: @aramase, @enj, @nabokihms
 	// kep: https://kep.k8s.io/3331
 	// alpha: v1.29
@@ -372,6 +376,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	StructuredAuthenticationConfiguration: {Default: true, PreRelease: featuregate.Beta},
 
 	StructuredAuthorizationConfiguration: {Default: true, PreRelease: featuregate.Beta},
+
+	StreamingCollectionEncodingToJSON: {Default: false, PreRelease: featuregate.Beta},
 
 	UnauthenticatedHTTP2DOSMitigation: {Default: true, PreRelease: featuregate.Beta},
 

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -942,6 +942,9 @@ func NewDefaultAPIGroupInfo(group string, scheme *runtime.Scheme, parameterCodec
 	if utilfeature.DefaultFeatureGate.Enabled(features.StreamingCollectionEncodingToJSON) {
 		opts = append(opts, serializer.WithStreamingCollectionEncodingToJSON())
 	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.StreamingCollectionEncodingToProtobuf) {
+		opts = append(opts, serializer.WithStreamingCollectionEncodingToProtobuf())
+	}
 	if len(opts) != 0 {
 		codecs = serializer.NewCodecFactory(scheme, opts...)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -938,6 +938,13 @@ func (s *GenericAPIServer) newAPIGroupVersion(apiGroupInfo *APIGroupInfo, groupV
 // NewDefaultAPIGroupInfo returns an APIGroupInfo stubbed with "normal" values
 // exposed for easier composition from other packages
 func NewDefaultAPIGroupInfo(group string, scheme *runtime.Scheme, parameterCodec runtime.ParameterCodec, codecs serializer.CodecFactory) APIGroupInfo {
+	opts := []serializer.CodecFactoryOptionsMutator{}
+	if utilfeature.DefaultFeatureGate.Enabled(features.StreamingCollectionEncodingToJSON) {
+		opts = append(opts, serializer.WithStreamingCollectionEncodingToJSON())
+	}
+	if len(opts) != 0 {
+		codecs = serializer.NewCodecFactory(scheme, opts...)
+	}
 	return APIGroupInfo{
 		PrioritizedVersions:          scheme.PrioritizedVersionsForGroup(group),
 		VersionedResourcesStorageMap: map[string]map[string]rest.Storage{},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1419,6 +1419,10 @@ sigs.k8s.io/kustomize/kyaml/yaml/merge2
 sigs.k8s.io/kustomize/kyaml/yaml/merge3
 sigs.k8s.io/kustomize/kyaml/yaml/schema
 sigs.k8s.io/kustomize/kyaml/yaml/walk
+# sigs.k8s.io/randfill v1.0.0
+## explicit; go 1.18
+sigs.k8s.io/randfill
+sigs.k8s.io/randfill/bytesource
 # sigs.k8s.io/structured-merge-diff/v4 v4.4.1
 ## explicit; go 1.13
 sigs.k8s.io/structured-merge-diff/v4/fieldpath

--- a/vendor/sigs.k8s.io/randfill/CONTRIBUTING.md
+++ b/vendor/sigs.k8s.io/randfill/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing Guidelines
+
+Welcome to Kubernetes. We are excited about the prospect of you joining our [community](https://git.k8s.io/community)! The Kubernetes community abides by the CNCF [code of conduct](code-of-conduct.md). Here is an excerpt:
+
+_As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities._
+
+## Getting Started
+
+We have full documentation on how to get started contributing here:
+
+<!---
+If your repo has certain guidelines for contribution, put them here ahead of the general k8s resources
+-->
+
+- [Contributor License Agreement](https://git.k8s.io/community/CLA.md) Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests
+- [Kubernetes Contributor Guide](https://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](https://git.k8s.io/community/contributors/guide#contributing)
+- [Contributor Cheat Sheet](https://git.k8s.io/community/contributors/guide/contributor-cheatsheet) - Common resources for existing developers
+
+## Mentorship
+
+- [Mentoring Initiatives](https://git.k8s.io/community/mentoring) - We have a diverse set of mentorship programs available that are always looking for volunteers!
+
+<!---
+Custom Information - if you're copying this template for the first time you can add custom content here, for example:
+
+## Contact Information
+
+- [Slack channel](https://kubernetes.slack.com/messages/kubernetes-users) - Replace `kubernetes-users` with your slack channel string, this will send users directly to your channel. 
+- [Mailing list](URL)
+
+-->
+
+## Project Management
+
+The [maintainers](https://github.com/kubernetes-sigs/randfill/blob/main/OWNERS_ALIASES#L12) of this project (and often others who have official positions on the [contributor ladder](https://github.com/kubernetes-sigs/randfill/blob/main/OWNERS_ALIASES)) are responsible for performing project management which oversees development and maintenance of the API, tests, tools, e.t.c. While we try to be generally flexible when it comes to the management of individual pieces (such as Issues or PRs), we have some rules and guidelines which help us plan, coordinate and reduce waste. In this section you'll find some rules/guidelines for contributors related to project management which may extend or go beyond what you would find in the standard [Kubernetes Contributor Guide](https://git.k8s.io/community/contributors/guide).
+
+### Bumping stale and closed Issues & PRs
+
+Maintainers are ultimately responsible for triaging new issues and PRs, accepting or declining them, deciding priority and fitting them into milestones intended for future releases. Bots are responsible for marking issues and PRs which stagnate as stale, or closing them if progress does not continue for a long period of time. Due to the nature of this community-driven development effort (we do not have dedicated engineering resources, we rely on the community which is effectively "volunteer time") **not all issues can be accepted, prioritized or completed**.
+
+You may find times when an issue you're subscribed to and interested in seems to stagnate, or perhaps gets auto-closed. Prior to bumping or directly re-opening issues yourself, we generally ask that you bring these up for discussion on the agenda for one of our community syncs if possible, or bring them up for discussion in Slack or the mailing list as this gives us a better opportunity to discuss the issue and determine viability and logistics. If feasible we **highly recommend being ready to contribute directly** to any stale or unprioritized effort that you want to see move forward, as **the best way to ensure progress is to engage with the community and personally invest time**.
+
+We (the community) aren't opposed to making exceptions in some cases, but when in doubt please follow the above guidelines before bumping closed or stale issues if you're not ready to personally invest time in them. We are responsible for managing these and without further context or engagement we may set these back to how they were previously organized.

--- a/vendor/sigs.k8s.io/randfill/LICENSE
+++ b/vendor/sigs.k8s.io/randfill/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2014 The gofuzz Authors
+   Copyright 2025 The Kubernetes Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/sigs.k8s.io/randfill/NOTICE
+++ b/vendor/sigs.k8s.io/randfill/NOTICE
@@ -1,0 +1,24 @@
+When donating the randfill project to the CNCF, we could not reach all the
+gofuzz contributors to sign the CNCF CLA. As such, according to the CNCF rules
+to donate a repository, we must add a NOTICE referencing section 7 of the CLA
+with a list of developers who could not be reached.
+
+`7. Should You wish to submit work that is not Your original creation, You may
+submit it to the Foundation separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which you are personally aware, and conspicuously marking the
+work as "Submitted on behalf of a third-party: [named here]".`
+
+Submitted on behalf of a third-party: @dnephin (Daniel Nephin)
+Submitted on behalf of a third-party: @AlekSi (Alexey Palazhchenko)
+Submitted on behalf of a third-party: @bbigras (Bruno Bigras)
+Submitted on behalf of a third-party: @samirkut (Samir)
+Submitted on behalf of a third-party: @posener (Eyal Posener)
+Submitted on behalf of a third-party: @Ashikpaul (Ashik Paul)
+Submitted on behalf of a third-party: @kwongtailau (Kwongtai)
+Submitted on behalf of a third-party: @ericcornelissen (Eric Cornelissen)
+Submitted on behalf of a third-party: @eclipseo (Robert-André Mauchin)
+Submitted on behalf of a third-party: @yanzhoupan (Andrew Pan)
+Submitted on behalf of a third-party: @STRRL (Zhiqiang ZHOU)
+Submitted on behalf of a third-party: @disconnect3d (Disconnect3d)

--- a/vendor/sigs.k8s.io/randfill/OWNERS
+++ b/vendor/sigs.k8s.io/randfill/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+# See the OWNERS_ALIASES file at https://github.com/kubernetes-sigs/randfill/blob/main/OWNERS_ALIASES for a list of members for each alias.
+
+approvers:
+  - sig-testing-leads
+  - thockin
+
+reviewers: []

--- a/vendor/sigs.k8s.io/randfill/OWNERS_ALIASES
+++ b/vendor/sigs.k8s.io/randfill/OWNERS_ALIASES
@@ -1,0 +1,14 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file should be kept in sync with k/org.
+
+aliases:
+  # Reference: https://github.com/kubernetes/org/blob/main/OWNERS_ALIASES
+  sig-testing-leads:
+    - BenTheElder
+    - alvaroaleman
+    - aojea
+    - cjwagner
+    - jbpratt
+    - michelle192837
+    - pohly
+    - xmcqueen

--- a/vendor/sigs.k8s.io/randfill/README.md
+++ b/vendor/sigs.k8s.io/randfill/README.md
@@ -1,0 +1,98 @@
+randfill
+======
+
+randfill is a library for populating go objects with random values.
+
+This is a fork of github.com/google/gofuzz, which was archived.
+
+NOTE: This repo is supported only for use within Kubernetes.  It is not our
+intention to support general use.  That said, if it works for you, that's
+great!  If you have a problem, please feel free to file an issue, but be aware
+that it may not be a priority for us to fix it unless it is affecting
+Kubernetes.  PRs are welcome, within reason.
+
+[![GoDoc](https://godoc.org/sigs.k8s.io/randfill?status.svg)](https://godoc.org/sigs.k8s.io/randfill)
+
+This is useful for testing:
+
+* Do your project's objects really serialize/unserialize correctly in all cases?
+* Is there an incorrectly formatted object that will cause your project to panic?
+
+Import with ```import "sigs.k8s.io/randfill"```
+
+You can use it on single variables:
+```go
+f := randfill.New()
+var myInt int
+f.Fill(&myInt) // myInt gets a random value.
+```
+
+You can use it on maps:
+```go
+f := randfill.New().NilChance(0).NumElements(1, 1)
+var myMap map[ComplexKeyType]string
+f.Fill(&myMap) // myMap will have exactly one element.
+```
+
+Customize the chance of getting a nil pointer:
+```go
+f := randfill.New().NilChance(.5)
+var fancyStruct struct {
+  A, B, C, D *string
+}
+f.Fill(&fancyStruct) // About half the pointers should be set.
+```
+
+You can even customize the randomization completely if needed:
+```go
+type MyEnum string
+const (
+        A MyEnum = "A"
+        B MyEnum = "B"
+)
+type MyInfo struct {
+        Type MyEnum
+        AInfo *string
+        BInfo *string
+}
+
+f := randfill.New().NilChance(0).Funcs(
+        func(e *MyInfo, c randfill.Continue) {
+                switch c.Intn(2) {
+                case 0:
+                        e.Type = A
+                        c.Fill(&e.AInfo)
+                case 1:
+                        e.Type = B
+                        c.Fill(&e.BInfo)
+                }
+        },
+)
+
+var myObject MyInfo
+f.Fill(&myObject) // Type will correspond to whether A or B info is set.
+```
+
+See more examples in ```example_test.go```.
+
+## dvyukov/go-fuzz integration
+
+You can use this library for easier [go-fuzz](https://github.com/dvyukov/go-fuzz)ing.
+go-fuzz provides the user a byte-slice, which should be converted to different inputs
+for the tested function. This library can help convert the byte slice. Consider for
+example a fuzz test for a the function `mypackage.MyFunc` that takes an int arguments:
+```go
+// +build gofuzz
+package mypackage
+
+import "sigs.k8s.io/randfill"
+
+func Fuzz(data []byte) int {
+        var i int
+        randfill.NewFromGoFuzz(data).Fill(&i)
+        MyFunc(i)
+        return 0
+}
+```
+
+Happy testing!

--- a/vendor/sigs.k8s.io/randfill/SECURITY_CONTACTS
+++ b/vendor/sigs.k8s.io/randfill/SECURITY_CONTACTS
@@ -1,0 +1,16 @@
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Product Security Committee to reach out
+# to for triaging and handling of incoming issues.
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://git.k8s.io/security/private-distributors-list.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://kubernetes.io/security/
+
+thockin
+BenTheElder
+aojea
+pohly

--- a/vendor/sigs.k8s.io/randfill/bytesource/bytesource.go
+++ b/vendor/sigs.k8s.io/randfill/bytesource/bytesource.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package bytesource provides a rand.Source64 that is determined by a slice of bytes.
+package bytesource
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"math/rand"
+)
+
+// ByteSource implements rand.Source64 determined by a slice of bytes. The random numbers are
+// generated from each 8 bytes in the slice, until the last bytes are consumed, from which a
+// fallback pseudo random source is created in case more random numbers are required.
+// It also exposes a `bytes.Reader` API, which lets callers consume the bytes directly.
+type ByteSource struct {
+	*bytes.Reader
+	fallback rand.Source
+}
+
+// New returns a new ByteSource from a given slice of bytes.
+func New(input []byte) *ByteSource {
+	s := &ByteSource{
+		Reader:   bytes.NewReader(input),
+		fallback: rand.NewSource(0),
+	}
+	if len(input) > 0 {
+		s.fallback = rand.NewSource(int64(s.consumeUint64()))
+	}
+	return s
+}
+
+func (s *ByteSource) Uint64() uint64 {
+	// Return from input if it was not exhausted.
+	if s.Len() > 0 {
+		return s.consumeUint64()
+	}
+
+	// Input was exhausted, return random number from fallback (in this case fallback should not be
+	// nil). Try first having a Uint64 output (Should work in current rand implementation),
+	// otherwise return a conversion of Int63.
+	if s64, ok := s.fallback.(rand.Source64); ok {
+		return s64.Uint64()
+	}
+	return uint64(s.fallback.Int63())
+}
+
+func (s *ByteSource) Int63() int64 {
+	return int64(s.Uint64() >> 1)
+}
+
+func (s *ByteSource) Seed(seed int64) {
+	s.fallback = rand.NewSource(seed)
+	s.Reader = bytes.NewReader(nil)
+}
+
+// consumeUint64 reads 8 bytes from the input and convert them to a uint64. It assumes that the the
+// bytes reader is not empty.
+func (s *ByteSource) consumeUint64() uint64 {
+	var bytes [8]byte
+	_, err := s.Read(bytes[:])
+	if err != nil && err != io.EOF {
+		panic("failed reading source") // Should not happen.
+	}
+	return binary.BigEndian.Uint64(bytes[:])
+}

--- a/vendor/sigs.k8s.io/randfill/code-of-conduct.md
+++ b/vendor/sigs.k8s.io/randfill/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/vendor/sigs.k8s.io/randfill/randfill.go
+++ b/vendor/sigs.k8s.io/randfill/randfill.go
@@ -1,0 +1,682 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+Copyright 2014 The gofuzz Authors.
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package randfill is a library for populating go objects with random values.
+package randfill
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"regexp"
+	"sync"
+	"time"
+	"unsafe"
+
+	"strings"
+
+	"sigs.k8s.io/randfill/bytesource"
+)
+
+// funcMap is a map from a type to a function that randfills that type.  The
+// function is a reflect.Value because the type being filled is different for
+// each func.
+type funcMap map[reflect.Type]reflect.Value
+
+// Filler knows how to fill any object with random fields.
+type Filler struct {
+	customFuncs           funcMap
+	defaultFuncs          funcMap
+	r                     *rand.Rand
+	nilChance             float64
+	minElements           int
+	maxElements           int
+	maxDepth              int
+	allowUnexportedFields bool
+	skipFieldPatterns     []*regexp.Regexp
+
+	lock sync.Mutex
+}
+
+// New returns a new Filler. Customize your Filler further by calling Funcs,
+// RandSource, NilChance, or NumElements in any order.
+func New() *Filler {
+	return NewWithSeed(time.Now().UnixNano())
+}
+
+func NewWithSeed(seed int64) *Filler {
+	f := &Filler{
+		defaultFuncs: funcMap{
+			reflect.TypeOf(&time.Time{}): reflect.ValueOf(randfillTime),
+		},
+
+		customFuncs:           funcMap{},
+		r:                     rand.New(rand.NewSource(seed)),
+		nilChance:             .2,
+		minElements:           1,
+		maxElements:           10,
+		maxDepth:              100,
+		allowUnexportedFields: false,
+	}
+	return f
+}
+
+// NewFromGoFuzz is a helper function that enables using randfill (this
+// project) with go-fuzz (https://github.com/dvyukov/go-fuzz) for continuous
+// fuzzing. Essentially, it enables translating the fuzzing bytes from
+// go-fuzz to any Go object using this library.
+//
+// This implementation promises a constant translation from a given slice of
+// bytes to the fuzzed objects. This promise will remain over future
+// versions of Go and of this library.
+//
+// Note: the returned Filler should not be shared between multiple goroutines,
+// as its deterministic output will no longer be available.
+//
+// Example: use go-fuzz to test the function `MyFunc(int)` in the package
+// `mypackage`. Add the file: "mypackage_fuzz.go" with the content:
+//
+// // +build gofuzz
+// package mypackage
+// import "sigs.k8s.io/randfill"
+//
+//	func Fuzz(data []byte) int {
+//		var i int
+//		randfill.NewFromGoFuzz(data).Fill(&i)
+//		MyFunc(i)
+//		return 0
+//	}
+func NewFromGoFuzz(data []byte) *Filler {
+	return New().RandSource(bytesource.New(data))
+}
+
+// Funcs registers custom fill functions for this Filler.
+//
+// Each entry in customFuncs must be a function taking two parameters.
+// The first parameter must be a pointer or map. It is the variable that
+// function will fill with random data. The second parameter must be a
+// randfill.Continue, which will provide a source of randomness and a way
+// to automatically continue filling smaller pieces of the first parameter.
+//
+// These functions are called sensibly, e.g., if you wanted custom string
+// filling, the function `func(s *string, c randfill.Continue)` would get
+// called and passed the address of strings. Maps and pointers will always
+// be made/new'd for you, ignoring the NilChance option. For slices, it
+// doesn't make much sense to pre-create them--Filler doesn't know how
+// long you want your slice--so take a pointer to a slice, and make it
+// yourself. (If you don't want your map/pointer type pre-made, take a
+// pointer to it, and make it yourself.) See the examples for a range of
+// custom functions.
+//
+// If a function is already registered for a type, and a new function is
+// provided, the previous function will be replaced with the new one.
+func (f *Filler) Funcs(customFuncs ...interface{}) *Filler {
+	for i := range customFuncs {
+		v := reflect.ValueOf(customFuncs[i])
+		if v.Kind() != reflect.Func {
+			panic("Filler.Funcs: all arguments must be functions")
+		}
+		t := v.Type()
+		if t.NumIn() != 2 || t.NumOut() != 0 {
+			panic("Filler.Funcs: all customFuncs must have 2 arguments and 0 returns")
+		}
+		argT := t.In(0)
+		switch argT.Kind() {
+		case reflect.Ptr, reflect.Map:
+		default:
+			panic("Filler.Funcs: customFuncs' first argument must be a pointer or map type")
+		}
+		if t.In(1) != reflect.TypeOf(Continue{}) {
+			panic("Filler.Funcs: customFuncs' second argument must be a randfill.Continue")
+		}
+		f.customFuncs[argT] = v
+	}
+	return f
+}
+
+// RandSource causes this Filler to get values from the given source of
+// randomness. Use this if you want deterministic filling.
+func (f *Filler) RandSource(s rand.Source) *Filler {
+	f.r = rand.New(s)
+	return f
+}
+
+// NilChance sets the probability of creating a nil pointer, map, or slice to
+// 'p'. 'p' should be between 0 (no nils) and 1 (all nils), inclusive.
+func (f *Filler) NilChance(p float64) *Filler {
+	if p < 0 || p > 1 {
+		panic("Filler.NilChance: p must be between 0 and 1, inclusive")
+	}
+	f.nilChance = p
+	return f
+}
+
+// NumElements sets the minimum and maximum number of elements that will be
+// added to a non-nil map or slice.
+func (f *Filler) NumElements(min, max int) *Filler {
+	if min < 0 {
+		panic("Filler.NumElements: min must be >= 0")
+	}
+	if min > max {
+		panic("Filler.NumElements: min must be <= max")
+	}
+	f.minElements = min
+	f.maxElements = max
+	return f
+}
+
+func (f *Filler) genElementCount() int {
+	if f.minElements == f.maxElements {
+		return f.minElements
+	}
+	return f.minElements + f.r.Intn(f.maxElements-f.minElements+1)
+}
+
+func (f *Filler) genShouldFill() bool {
+	return f.r.Float64() >= f.nilChance
+}
+
+// MaxDepth sets the maximum number of recursive fill calls that will be made
+// before stopping.  This includes struct members, pointers, and map and slice
+// elements.
+func (f *Filler) MaxDepth(d int) *Filler {
+	f.maxDepth = d
+	return f
+}
+
+// AllowUnexportedFields defines whether to fill unexported fields.
+func (f *Filler) AllowUnexportedFields(flag bool) *Filler {
+	f.allowUnexportedFields = flag
+	return f
+}
+
+// SkipFieldsWithPattern tells this Filler to skip any field whose name matches
+// the supplied pattern. Call this multiple times if needed. This is useful to
+// skip XXX_ fields generated by protobuf.
+func (f *Filler) SkipFieldsWithPattern(pattern *regexp.Regexp) *Filler {
+	f.skipFieldPatterns = append(f.skipFieldPatterns, pattern)
+	return f
+}
+
+// SimpleSelfFiller represents an object that knows how to randfill itself.
+//
+// Unlike NativeSelfFiller, this interface does not cause the type in question
+// to depend on the randfill package.  This is most useful for simple types.  For
+// more complex types, consider using NativeSelfFiller.
+type SimpleSelfFiller interface {
+	// RandFill fills the current object with random data.
+	RandFill(r *rand.Rand)
+}
+
+// NativeSelfFiller represents an object that knows how to randfill itself.
+//
+// Unlike SimpleSelfFiller, this interface allows for recursive filling of
+// child objects with the same rules as the parent Filler.
+type NativeSelfFiller interface {
+	// RandFill fills the current object with random data.
+	RandFill(c Continue)
+}
+
+// Fill recursively fills all of obj's fields with something random.  First
+// this tries to find a custom fill function (see Funcs).  If there is no
+// custom function, this tests whether the object implements SimpleSelfFiller
+// or NativeSelfFiller and if so, calls RandFill on it to fill itself.  If that
+// fails, this will see if there is a default fill function provided by this
+// package. If all of that fails, this will generate random values for all
+// primitive fields and then recurse for all non-primitives.
+//
+// This is safe for cyclic or tree-like structs, up to a limit.  Use the
+// MaxDepth method to adjust how deep you need it to recurse.
+//
+// obj must be a pointer. Exported (public) fields can always be set, and if
+// the AllowUnexportedFields() modifier was called it can try to set unexported
+// (private) fields, too.
+//
+// This is intended for tests, so will panic on bad input or unimplemented
+// types.  This method takes a lock for the whole Filler, so it is not
+// reentrant.  See Continue.
+func (f *Filler) Fill(obj interface{}) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr {
+		panic("Filler.Fill: obj must be a pointer")
+	}
+	v = v.Elem()
+	f.fillWithContext(v, 0)
+}
+
+// FillNoCustom is just like Fill, except that any custom fill function for
+// obj's type will not be called and obj will not be tested for
+// SimpleSelfFiller or NativeSelfFiller. This applies only to obj and not other
+// instances of obj's type or to obj's child fields.
+//
+// obj must be a pointer. Exported (public) fields can always be set, and if
+// the AllowUnexportedFields() modifier was called it can try to set unexported
+// (private) fields, too.
+//
+// This is intended for tests, so will panic on bad input or unimplemented
+// types.  This method takes a lock for the whole Filler, so it is not
+// reentrant.  See Continue.
+func (f *Filler) FillNoCustom(obj interface{}) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr {
+		panic("Filler.FillNoCustom: obj must be a pointer")
+	}
+	v = v.Elem()
+	f.fillWithContext(v, flagNoCustomFill)
+}
+
+const (
+	// Do not try to find a custom fill function.  Does not apply recursively.
+	flagNoCustomFill uint64 = 1 << iota
+)
+
+func (f *Filler) fillWithContext(v reflect.Value, flags uint64) {
+	fc := &fillerContext{filler: f}
+	fc.doFill(v, flags)
+}
+
+// fillerContext carries context about a single filling run, which lets Filler
+// be thread-safe.
+type fillerContext struct {
+	filler   *Filler
+	curDepth int
+}
+
+func (fc *fillerContext) doFill(v reflect.Value, flags uint64) {
+	if fc.curDepth >= fc.filler.maxDepth {
+		return
+	}
+	fc.curDepth++
+	defer func() { fc.curDepth-- }()
+
+	if !v.CanSet() {
+		if !fc.filler.allowUnexportedFields || !v.CanAddr() {
+			return
+		}
+		v = reflect.NewAt(v.Type(), unsafe.Pointer(v.UnsafeAddr())).Elem()
+	}
+
+	if flags&flagNoCustomFill == 0 {
+		// Check for both pointer and non-pointer custom functions.
+		if v.CanAddr() && fc.tryCustom(v.Addr()) {
+			return
+		}
+		if fc.tryCustom(v) {
+			return
+		}
+	}
+
+	if fn, ok := fillFuncMap[v.Kind()]; ok {
+		fn(v, fc.filler.r)
+		return
+	}
+
+	switch v.Kind() {
+	case reflect.Map:
+		if fc.filler.genShouldFill() {
+			v.Set(reflect.MakeMap(v.Type()))
+			n := fc.filler.genElementCount()
+			for i := 0; i < n; i++ {
+				key := reflect.New(v.Type().Key()).Elem()
+				fc.doFill(key, 0)
+				val := reflect.New(v.Type().Elem()).Elem()
+				fc.doFill(val, 0)
+				v.SetMapIndex(key, val)
+			}
+			return
+		}
+		v.Set(reflect.Zero(v.Type()))
+	case reflect.Ptr:
+		if fc.filler.genShouldFill() {
+			v.Set(reflect.New(v.Type().Elem()))
+			fc.doFill(v.Elem(), 0)
+			return
+		}
+		v.Set(reflect.Zero(v.Type()))
+	case reflect.Slice:
+		if fc.filler.genShouldFill() {
+			n := fc.filler.genElementCount()
+			v.Set(reflect.MakeSlice(v.Type(), n, n))
+			for i := 0; i < n; i++ {
+				fc.doFill(v.Index(i), 0)
+			}
+			return
+		}
+		v.Set(reflect.Zero(v.Type()))
+	case reflect.Array:
+		if fc.filler.genShouldFill() {
+			n := v.Len()
+			for i := 0; i < n; i++ {
+				fc.doFill(v.Index(i), 0)
+			}
+			return
+		}
+		v.Set(reflect.Zero(v.Type()))
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			skipField := false
+			fieldName := v.Type().Field(i).Name
+			for _, pattern := range fc.filler.skipFieldPatterns {
+				if pattern.MatchString(fieldName) {
+					skipField = true
+					break
+				}
+			}
+			if !skipField {
+				fc.doFill(v.Field(i), 0)
+			}
+		}
+	case reflect.Chan:
+		fallthrough
+	case reflect.Func:
+		fallthrough
+	case reflect.Interface:
+		fallthrough
+	default:
+		panic(fmt.Sprintf("can't fill type %v, kind %v", v.Type(), v.Kind()))
+	}
+}
+
+// tryCustom searches for custom handlers, and returns true iff it finds a match
+// and successfully randomizes v.
+func (fc *fillerContext) tryCustom(v reflect.Value) bool {
+	// First: see if we have a fill function for it.
+	doCustom, ok := fc.filler.customFuncs[v.Type()]
+	if !ok {
+		// Second: see if it can fill itself.
+		if v.CanInterface() {
+			intf := v.Interface()
+			if fillable, ok := intf.(SimpleSelfFiller); ok {
+				fillable.RandFill(fc.filler.r)
+				return true
+			}
+			if fillable, ok := intf.(NativeSelfFiller); ok {
+				fillable.RandFill(Continue{fc: fc, Rand: fc.filler.r})
+				return true
+			}
+		}
+		// Finally: see if there is a default fill function.
+		doCustom, ok = fc.filler.defaultFuncs[v.Type()]
+		if !ok {
+			return false
+		}
+	}
+
+	switch v.Kind() {
+	case reflect.Ptr:
+		if v.IsNil() {
+			if !v.CanSet() {
+				return false
+			}
+			v.Set(reflect.New(v.Type().Elem()))
+		}
+	case reflect.Map:
+		if v.IsNil() {
+			if !v.CanSet() {
+				return false
+			}
+			v.Set(reflect.MakeMap(v.Type()))
+		}
+	default:
+		return false
+	}
+
+	doCustom.Call([]reflect.Value{
+		v,
+		reflect.ValueOf(Continue{
+			fc:   fc,
+			Rand: fc.filler.r,
+		}),
+	})
+	return true
+}
+
+// Continue can be passed to custom fill functions to allow them to use
+// the correct source of randomness and to continue filling their members.
+type Continue struct {
+	fc *fillerContext
+
+	// For convenience, Continue implements rand.Rand via embedding.
+	// Use this for generating any randomness if you want your filling
+	// to be repeatable for a given seed.
+	*rand.Rand
+}
+
+// Fill continues filling obj. obj must be a pointer or a reflect.Value of a
+// pointer.  See Filler.Fill.
+func (c Continue) Fill(obj interface{}) {
+	v, ok := obj.(reflect.Value)
+	if !ok {
+		v = reflect.ValueOf(obj)
+	}
+	if v.Kind() != reflect.Ptr {
+		panic("Continue.Fill: obj must be a pointer")
+	}
+	v = v.Elem()
+	c.fc.doFill(v, 0)
+}
+
+// FillNoCustom continues filling obj, except that any custom fill function for
+// obj's type will not be called and obj will not be tested for
+// SimpleSelfFiller or NativeSelfFiller.  See Filler.FillNoCustom.
+func (c Continue) FillNoCustom(obj interface{}) {
+	v, ok := obj.(reflect.Value)
+	if !ok {
+		v = reflect.ValueOf(obj)
+	}
+	if v.Kind() != reflect.Ptr {
+		panic("Continue.FillNoCustom: obj must be a pointer")
+	}
+	v = v.Elem()
+	c.fc.doFill(v, flagNoCustomFill)
+}
+
+const defaultStringMaxLen = 20
+
+// String makes a random string up to n characters long. If n is 0, the default
+// size range is [0-20). The returned string may include a variety of (valid)
+// UTF-8 encodings.
+func (c Continue) String(n int) string {
+	return randString(c.Rand, n)
+}
+
+// Uint64 makes random 64 bit numbers.
+// Weirdly, rand doesn't have a function that gives you 64 random bits.
+func (c Continue) Uint64() uint64 {
+	return randUint64(c.Rand)
+}
+
+// Bool returns true or false randomly.
+func (c Continue) Bool() bool {
+	return randBool(c.Rand)
+}
+
+func fillInt(v reflect.Value, r *rand.Rand) {
+	v.SetInt(int64(randUint64(r)))
+}
+
+func fillUint(v reflect.Value, r *rand.Rand) {
+	v.SetUint(randUint64(r))
+}
+
+func randfillTime(t *time.Time, c Continue) {
+	var sec, nsec int64
+	// Allow for about 1000 years of random time values, which keeps things
+	// like JSON parsing reasonably happy.
+	sec = c.Rand.Int63n(1000 * 365 * 24 * 60 * 60)
+	// Nanosecond values greater than 1Bn are technically allowed but result in
+	// time.Time values with invalid timezone offsets.
+	nsec = c.Rand.Int63n(999999999)
+	*t = time.Unix(sec, nsec)
+}
+
+var fillFuncMap = map[reflect.Kind]func(reflect.Value, *rand.Rand){
+	reflect.Bool: func(v reflect.Value, r *rand.Rand) {
+		v.SetBool(randBool(r))
+	},
+	reflect.Int:     fillInt,
+	reflect.Int8:    fillInt,
+	reflect.Int16:   fillInt,
+	reflect.Int32:   fillInt,
+	reflect.Int64:   fillInt,
+	reflect.Uint:    fillUint,
+	reflect.Uint8:   fillUint,
+	reflect.Uint16:  fillUint,
+	reflect.Uint32:  fillUint,
+	reflect.Uint64:  fillUint,
+	reflect.Uintptr: fillUint,
+	reflect.Float32: func(v reflect.Value, r *rand.Rand) {
+		v.SetFloat(float64(r.Float32()))
+	},
+	reflect.Float64: func(v reflect.Value, r *rand.Rand) {
+		v.SetFloat(r.Float64())
+	},
+	reflect.Complex64: func(v reflect.Value, r *rand.Rand) {
+		v.SetComplex(complex128(complex(r.Float32(), r.Float32())))
+	},
+	reflect.Complex128: func(v reflect.Value, r *rand.Rand) {
+		v.SetComplex(complex(r.Float64(), r.Float64()))
+	},
+	reflect.String: func(v reflect.Value, r *rand.Rand) {
+		v.SetString(randString(r, 0))
+	},
+	reflect.UnsafePointer: func(v reflect.Value, r *rand.Rand) {
+		panic("filling of UnsafePointers is not implemented")
+	},
+}
+
+// randBool returns true or false randomly.
+func randBool(r *rand.Rand) bool {
+	return r.Int31()&(1<<30) == 0
+}
+
+type int63nPicker interface {
+	Int63n(int64) int64
+}
+
+// UnicodeRange describes a sequential range of unicode characters.
+// Last must be numerically greater than First.
+type UnicodeRange struct {
+	First, Last rune
+}
+
+// UnicodeRanges describes an arbitrary number of sequential ranges of unicode characters.
+// To be useful, each range must have at least one character (First <= Last) and
+// there must be at least one range.
+type UnicodeRanges []UnicodeRange
+
+// choose returns a random unicode character from the given range, using the
+// given randomness source.
+func (ur UnicodeRange) choose(r int63nPicker) rune {
+	count := int64(ur.Last - ur.First + 1)
+	return ur.First + rune(r.Int63n(count))
+}
+
+// CustomStringFillFunc constructs a FillFunc which produces random strings.
+// Each character is selected from the range ur. If there are no characters
+// in the range (cr.Last < cr.First), this will panic.
+func (ur UnicodeRange) CustomStringFillFunc(n int) func(s *string, c Continue) {
+	ur.check()
+	return func(s *string, c Continue) {
+		*s = ur.randString(c.Rand, n)
+	}
+}
+
+// check is a function that used to check whether the first of ur(UnicodeRange)
+// is greater than the last one.
+func (ur UnicodeRange) check() {
+	if ur.Last < ur.First {
+		panic("UnicodeRange.check: the last encoding must be greater than the first")
+	}
+}
+
+// randString of UnicodeRange makes a random string up to 20 characters long.
+// Each character is selected form ur(UnicodeRange).
+func (ur UnicodeRange) randString(r *rand.Rand, max int) string {
+	if max == 0 {
+		max = defaultStringMaxLen
+	}
+	n := r.Intn(max)
+	sb := strings.Builder{}
+	sb.Grow(n)
+	for i := 0; i < n; i++ {
+		sb.WriteRune(ur.choose(r))
+	}
+	return sb.String()
+}
+
+// defaultUnicodeRanges sets a default unicode range when users do not set
+// CustomStringFillFunc() but want to fill strings.
+var defaultUnicodeRanges = UnicodeRanges{
+	{' ', '~'},           // ASCII characters
+	{'\u00a0', '\u02af'}, // Multi-byte encoded characters
+	{'\u4e00', '\u9fff'}, // Common CJK (even longer encodings)
+}
+
+// CustomStringFillFunc constructs a FillFunc which produces random strings.
+// Each character is selected from one of the ranges of ur(UnicodeRanges).
+// Each range has an equal probability of being chosen. If there are no ranges,
+// or a selected range has no characters (.Last < .First), this will panic.
+// Do not modify any of the ranges in ur after calling this function.
+func (ur UnicodeRanges) CustomStringFillFunc(n int) func(s *string, c Continue) {
+	// Check unicode ranges slice is empty.
+	if len(ur) == 0 {
+		panic("UnicodeRanges is empty")
+	}
+	// if not empty, each range should be checked.
+	for i := range ur {
+		ur[i].check()
+	}
+	return func(s *string, c Continue) {
+		*s = ur.randString(c.Rand, n)
+	}
+}
+
+// randString of UnicodeRanges makes a random string up to 20 characters long.
+// Each character is selected form one of the ranges of ur(UnicodeRanges),
+// and each range has an equal probability of being chosen.
+func (ur UnicodeRanges) randString(r *rand.Rand, max int) string {
+	if max == 0 {
+		max = defaultStringMaxLen
+	}
+	n := r.Intn(max)
+	sb := strings.Builder{}
+	sb.Grow(n)
+	for i := 0; i < n; i++ {
+		sb.WriteRune(ur[r.Intn(len(ur))].choose(r))
+	}
+	return sb.String()
+}
+
+// randString makes a random string up to 20 characters long. The returned string
+// may include a variety of (valid) UTF-8 encodings.
+func randString(r *rand.Rand, max int) string {
+	return defaultUnicodeRanges.randString(r, max)
+}
+
+// randUint64 makes random 64 bit numbers.
+// Weirdly, rand doesn't have a function that gives you 64 random bits.
+func randUint64(r *rand.Rand) uint64 {
+	return uint64(r.Uint32())<<32 | uint64(r.Uint32())
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Reduce memory usage

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

NOTE: There are some adjustments because of conflict.

```
    * v1.30 doesn't have StrictSerializer for CRD handler, so there is no
      new streaming option for that.
      staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go

    * Remove CBORServingAndStorage option when create codec_factory.
      staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go

    * Remove two files since we don't need it in v1.30.x
      * pkg/features/versioned_kube_features.go
      * test/featuregates_linter/test_data/versioned_feature_list.yaml

    * Add "sigs.k8s.io/randfill" deps
 
    * By default, disable this feature
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
